### PR TITLE
Improve Reindexing Mods

### DIFF
--- a/src/components/viewblock/Settings.svelte
+++ b/src/components/viewblock/Settings.svelte
@@ -30,20 +30,6 @@
 		}
 	}
 
-	async function confirmReindex() {
-		try {
-			await invoke("refresh_mods_folder");
-			addMessage("Mods re-indexed successfully", "success");
-		} catch (error) {
-			addMessage("Failed to re-index mods: " + error, "error");
-		}
-		showWarningPopup.set(false);
-	}
-
-	function reindexModsWithWarning() {
-		showWarningPopup.set(true);
-	} // Called when the popup's confirm button is pressed
-
 	async function clearCache() {
 		isClearingCache = true;
 		try {

--- a/src/components/viewblock/Settings.svelte
+++ b/src/components/viewblock/Settings.svelte
@@ -4,16 +4,25 @@
 	import { addMessage } from "$lib/stores";
 	import { onMount } from "svelte";
 	import { invoke } from "@tauri-apps/api/core";
-	import WarningPopup from "../WarningPopup.svelte";
-    import { showWarningPopup } from "../../stores/modStore";
+	import { showWarningPopup } from "../../stores/modStore";
 	let isReindexing = false;
 	let isClearingCache = false;
 	let isConsoleEnabled = false;
+
 	export async function performReindexMods() {
 		isReindexing = true;
 		try {
-			await invoke("refresh_mods_folder");
-			addMessage("Successfully re-indexed mods!", "success");
+			const hasUntracked = await invoke<boolean>("check_untracked_mods");
+
+			if (hasUntracked) {
+				showWarningPopup.set(true);
+			} else {
+				await invoke("refresh_mods_folder");
+				addMessage(
+					"Mods re-indexed - no untracked files found",
+					"success",
+				);
+			}
 		} catch (error) {
 			addMessage("Failed to re-index mods: " + error, "error");
 		} finally {
@@ -21,16 +30,20 @@
 		}
 	}
 
+	async function confirmReindex() {
+		try {
+			await invoke("refresh_mods_folder");
+			addMessage("Mods re-indexed successfully", "success");
+		} catch (error) {
+			addMessage("Failed to re-index mods: " + error, "error");
+		}
+		showWarningPopup.set(false);
+	}
+
 	function reindexModsWithWarning() {
 		showWarningPopup.set(true);
 	} // Called when the popup's confirm button is pressed
-	function confirmReindex() {
-		showWarningPopup.set(false);
-		performReindexMods();
-	} // Called when the popup's cancel button is pressed
-	function cancelReindex() {
-		showWarningPopup.set(false);
-	}
+
 	async function clearCache() {
 		isClearingCache = true;
 		try {
@@ -91,10 +104,11 @@
 		</p>
 
 		<h3>Mods</h3>
+
 		<div class="mods-settings">
 			<button
 				class="reindex-button"
-				on:click={reindexModsWithWarning}
+				on:click={performReindexMods}
 				disabled={isReindexing}
 			>
 				{#if isReindexing}

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -9,6 +9,8 @@
 	import type { DependencyCheck } from "../../stores/modStore";
 	import { showWarningPopup } from "../../stores/modStore";
 	import { performReindexMods } from "../../utils/performReindexMods";
+	import { invoke } from "@tauri-apps/api/core";
+	import { addMessage } from "$lib/stores";
 
 	let currentSection = "mods";
 	// window.addEventListener("resize", () => {
@@ -35,12 +37,13 @@
 		showRequiresPopup = true;
 	}
 
-	function confirmReindex() {
-		performReindexMods();
-		showWarningPopup.set(false);
-	}
-
-	function cancelReindex() {
+	async function confirmReindex() {
+		try {
+			await invoke("refresh_mods_folder");
+			addMessage("Mods re-indexed successfully", "success");
+		} catch (error) {
+			addMessage("Failed to re-index mods: " + error, "error");
+		}
 		showWarningPopup.set(false);
 	}
 </script>
@@ -92,11 +95,12 @@
 		requiresSteamodded={modRequirements.steamodded}
 		requiresTalisman={modRequirements.talisman}
 	/>
+
 	<WarningPopup
 		visible={$showWarningPopup}
-		message="Warning: All mods in the Mods directory that are not tracked in the database will be deleted. Are you sure you want to proceed?"
+		message="Untracked mods detected! All mods in the Mods directory that are not tracked in the database will be deleted. Are you sure you want to proceed?"
 		onConfirm={confirmReindex}
-		onCancel={cancelReindex}
+		onCancel={() => showWarningPopup.set(false)}
 	/>
 
 	<div class="version-text">v0.1.0</div>

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -8,7 +8,6 @@
 	import WarningPopup from "../../components/WarningPopup.svelte";
 	import type { DependencyCheck } from "../../stores/modStore";
 	import { showWarningPopup } from "../../stores/modStore";
-	import { performReindexMods } from "../../utils/performReindexMods";
 	import { invoke } from "@tauri-apps/api/core";
 	import { addMessage } from "$lib/stores";
 

--- a/src/utils/performReindexMods.ts
+++ b/src/utils/performReindexMods.ts
@@ -1,12 +1,29 @@
 import { addMessage } from "$lib/stores";
 import { invoke } from "@tauri-apps/api/core";
+import { showWarningPopup } from "../stores/modStore";
+
 
 export async function performReindexMods() {
 	try {
-		await invoke("refresh_mods_folder");
-		addMessage("Successfully re-indexed mods!", "success");
+		const hasUntracked = await invoke<boolean>('check_untracked_mods');
+
+		if (hasUntracked) {
+			showWarningPopup.set(true);
+		} else {
+			await invoke("refresh_mods_folder");
+			addMessage("Mods re-indexed successfully", "success");
+		}
 	} catch (error) {
-		addMessage("Failed to re-index mods: " + error, "error");
+		addMessage("Failed to check mod status: " + error, "error");
 	}
 }
 
+export async function confirmReindex() {
+	try {
+		await invoke("refresh_mods_folder");
+		addMessage("Mods re-indexed successfully", "success");
+	} catch (error) {
+		addMessage("Failed to re-index mods: " + error, "error");
+	}
+	showWarningPopup.set(false);
+}


### PR DESCRIPTION
This pull request introduces a new feature to check for untracked mods before re-indexing and includes several changes across multiple files to implement this feature. The most important changes include adding a new command to check for untracked mods, updating the reindexing process to include this check, and modifying the UI to handle the new workflow.

### New Feature: Check for Untracked Mods

* [`src-tauri/src/lib.rs`](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR108-R147): Added a new command `check_untracked_mods` to check for untracked mods in the mods directory. This command reads the mods directory and compares it with the installed mods in the database.
* [`src-tauri/src/lib.rs`](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR574): Registered the new `check_untracked_mods` command in the Tauri application.

### Reindexing Process Updates

* [`src/components/viewblock/Settings.svelte`](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351L7-L33): Updated the `performReindexMods` function to invoke `check_untracked_mods` before re-indexing mods. If untracked mods are found, a warning popup is shown. [[1]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351L7-L33) [[2]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351R93-R97)

### UI Modifications

* [`src/routes/main/+page.svelte`](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL11-R12): Updated the reindexing process to handle the new workflow, including showing a warning popup if untracked mods are detected. [[1]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL11-R12) [[2]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL38-L43) [[3]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR97-R102)
* [`src/utils/performReindexMods.ts`](diffhunk://#diff-f4bd2e3b5b2316ea999118ee004e52786238157213262e76a63ac8bcf9fefcadR3-R29): Added a new function `confirmReindex` to handle the confirmation of reindexing after the warning popup is shown.