### PR TITLE
Mouse Back Button Support

### DIFF
--- a/src/components/viewblock/ModView.svelte
+++ b/src/components/viewblock/ModView.svelte
@@ -22,6 +22,14 @@
 	import { cachedVersions } from "../../stores/modStore";
 	import { onDestroy } from "svelte";
 
+	function handleAuxClick(event: MouseEvent) {
+		// Back button (typically button 3)
+		if (event.button === 3) {
+			event.preventDefault();
+			handleClose();
+		}
+	}
+
 	const VERSION_CACHE_DURATION = 60 * 60 * 1000; // 60 minutes
 
 	const dispatch = createEventDispatcher<{
@@ -337,6 +345,7 @@
 	}
 
 	onMount(async () => {
+		window.addEventListener("auxclick", handleAuxClick);
 		if (mod) {
 			await getAllInstalledMods();
 			await isModInstalled(mod);
@@ -369,23 +378,20 @@
 	}
 
 	onDestroy(async () => {
+		window.removeEventListener("auxclick", handleAuxClick);
 		// Optional: Clear memory cache if needed
 		cachedVersions.set({ steamodded: [], talisman: [] });
 	});
-
-	//
-	// $: if (mod) {
-	// 	isModInstalled(mod);
-	// }
-	// $: if (mod?.title?.toLowerCase() === "steamodded") {
-	// 	loadSteamoddedVersions();
-	// }
-
-	// $: if (mod?.title?.toLowerCase() === "steamodded") {
-	// 	versionLoadAttempted = false;
-	// 	loadSteamoddedVersions();
-	// }
 </script>
+
+<!-- Add keyboard navigation support as fallback -->
+<svelte:window
+	on:keydown={(e) => {
+		if (e.key === "Backspace" || e.key === "Escape") {
+			handleClose();
+		}
+	}}
+/>
 
 {#if $currentModView}
 	<div


### PR DESCRIPTION
This pull request includes updates to the `ModView.svelte` component to enhance user interaction by handling auxiliary mouse clicks and adding keyboard navigation support.

Enhancements to user interaction:

* Added `handleAuxClick` function to handle auxiliary mouse clicks, specifically the back button (typically button 3).
* Registered `handleAuxClick` event listener on the `window` object during component mount and removed it during component destroy to ensure proper event handling and cleanup. [[1]](diffhunk://#diff-3ef7db5f7bd6ad5282fdb2f7b73543c92bd3e2fdb0a6739616762e10b733cf74R348) [[2]](diffhunk://#diff-3ef7db5f7bd6ad5282fdb2f7b73543c92bd3e2fdb0a6739616762e10b733cf74R381-R395)

Keyboard navigation support:

* Added a `<svelte:window>` element to handle `Backspace` and `Escape` key presses, allowing users to close the view using these keys.