### PR TITLE
37 mods page sorting

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "npm:@sveltejs/adapter-static@^3.0.8": "3.0.8_@sveltejs+kit@2.17.1__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.20.0____acorn@8.14.0___vite@6.1.0__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0",
     "npm:@sveltejs/kit@^2.17.1": "2.17.1_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0",
+    "npm:@sveltejs/kit@^2.17.2": "2.17.2_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0",
     "npm:@sveltejs/vite-plugin-svelte@^5.0.3": "5.0.3_svelte@5.20.0__acorn@8.14.0_vite@6.1.0",
     "npm:@tauri-apps/api@^2.2.0": "2.2.0",
     "npm:@tauri-apps/cli@^2.2.7": "2.2.7",
@@ -193,11 +194,30 @@
     "@sveltejs/adapter-static@3.0.8_@sveltejs+kit@2.17.1__@sveltejs+vite-plugin-svelte@5.0.3___svelte@5.20.0____acorn@8.14.0___vite@6.1.0__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0": {
       "integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
       "dependencies": [
-        "@sveltejs/kit"
+        "@sveltejs/kit@2.17.1_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0"
       ]
     },
     "@sveltejs/kit@2.17.1_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0": {
       "integrity": "sha512-CpoGSLqE2MCmcQwA2CWJvOsZ9vW+p/1H3itrFykdgajUNAEyQPbsaSn7fZb6PLHQwe+07njxje9ss0fjZoCAyw==",
+      "dependencies": [
+        "@sveltejs/vite-plugin-svelte",
+        "@types/cookie",
+        "cookie",
+        "devalue",
+        "esm-env",
+        "import-meta-resolve",
+        "kleur",
+        "magic-string",
+        "mrmime",
+        "sade",
+        "set-cookie-parser",
+        "sirv",
+        "svelte",
+        "vite"
+      ]
+    },
+    "@sveltejs/kit@2.17.2_@sveltejs+vite-plugin-svelte@5.0.3__svelte@5.20.0___acorn@8.14.0__vite@6.1.0_svelte@5.20.0__acorn@8.14.0_vite@6.1.0": {
+      "integrity": "sha512-Vypk02baf7qd3SOB1uUwUC/3Oka+srPo2J0a8YN3EfJypRshDkNx9HzNKjSmhOnGWwT+SSO06+N0mAb8iVTmTQ==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte",
         "@types/cookie",
@@ -619,7 +639,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@sveltejs/adapter-static@^3.0.8",
-        "npm:@sveltejs/kit@^2.17.1",
+        "npm:@sveltejs/kit@^2.17.2",
         "npm:@sveltejs/vite-plugin-svelte@^5.0.3",
         "npm:@tauri-apps/api@^2.2.0",
         "npm:@tauri-apps/cli@^2.2.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.8",
-    "@sveltejs/kit": "^2.17.1",
+    "@sveltejs/kit": "^2.17.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "lucide-svelte": "^0.475.0",
     "marked": "^15.0.7",

--- a/src/stores/modStore.ts
+++ b/src/stores/modStore.ts
@@ -15,6 +15,15 @@ export interface Mod {
 	downloadURL: string;
 }
 
+export enum SortOption {
+	NameAsc = "name_asc",
+	NameDesc = "name_desc",
+	LastUpdatedAsc = "updated_asc",
+	LastUpdatedDesc = "updated_desc"
+}
+
+export const currentSort = writable<SortOption>(SortOption.NameAsc);
+
 export interface UninstallDialogState {
 	show: boolean;
 	modName: string;


### PR DESCRIPTION
This pull request introduces a sorting feature for the mods displayed in the `Mods.svelte` component, along with some styling adjustments and a minor dependency update. The most important changes include adding sorting functionality, updating the `package.json` dependency, and enhancing the UI for sorting controls and responsiveness.

### Sorting Functionality:
* [`src/components/viewblock/Mods.svelte`](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR548-R571): Added sorting logic and a dropdown to select sorting options. The `sortMods` function sorts the mods based on the selected option, and the `handleSortChange` function updates the current sort option. [[1]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR548-R571) [[2]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR596-R620)
* [`src/stores/modStore.ts`](diffhunk://#diff-ceb9481d4a9134a98aa4ea64d8231c54e1a6778c30246b9c2b6b9b2e085b4530R18-R26): Introduced `SortOption` enum and `currentSort` writable store to manage the sorting state.

### Dependency Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28): Updated `@sveltejs/kit` from version `^2.17.1` to `^2.17.2`.

### UI Enhancements:
* [`src/components/viewblock/Mods.svelte`](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR817-R886): Added a fixed position for the sorting controls and improved the styling for better user experience.
* [`src/components/viewblock/Mods.svelte`](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR1074-R1179): Included media queries to ensure the layout is responsive on different screen sizes.