### PR TITLE
41 reindexing mods does not recognize

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -370,6 +370,70 @@ async fn force_remove_mod(
 }
 
 #[tauri::command]
+async fn reindex_mods(state: tauri::State<'_, AppState>) -> Result<(usize, usize), String> {
+    let mod_dir = dirs::config_dir()
+        .ok_or_else(|| AppError::DirNotFound(PathBuf::from("config directory")))?
+        .join("Balatro")
+        .join("Mods");
+
+    let db = state
+        .db
+        .lock()
+        .map_err(|e| AppError::LockPoisoned("Database lock poisoned".to_string()))?;
+    
+    // Phase 1: Filesystem cleanup
+    let mut files_removed = 0;
+    let installed_mods = db.get_installed_mods().map_err(|e| e.to_string())?;
+    
+    match std::fs::read_dir(&mod_dir) {
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = match path.file_name().and_then(|n| n.to_str()) {
+                    Some(n) if !n.contains("lovely") => n,
+                    _ => continue,
+                };
+
+                if !installed_mods.iter().any(|m| m.path.contains(name)) {
+                    match entry.file_type() {
+                        Ok(ft) => {
+                            if ft.is_dir() {
+                                std::fs::remove_dir_all(&path).ok();
+                            } else if ft.is_file() {
+                                std::fs::remove_file(&path).ok();
+                            }
+                            files_removed += 1;
+                        }
+                        Err(_) => continue,
+                    }
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.to_string()),
+    }
+
+    // Phase 2: Database cleanup
+    let installed_mods = db.get_installed_mods().map_err(|e| e.to_string())?;
+    let mut cleaned_entries = 0;
+    let mut to_remove = Vec::new();
+
+    for (index, installed_mod) in installed_mods.iter().enumerate() {
+        if !PathBuf::from(&installed_mod.path).exists() {
+            to_remove.push(index);
+        }
+    }
+
+    cleaned_entries = to_remove.len();
+    for &index in to_remove.iter().rev() {
+        db.remove_installed_mod(&installed_mods[index].name)
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok((files_removed, cleaned_entries))
+}
+
+#[tauri::command]
 async fn get_dependents(mod_name: String) -> Result<Vec<String>, String> {
     let db = Database::new().map_err(|e| e.to_string())?;
     db.get_dependents(&mod_name).map_err(|e| e.to_string())
@@ -620,7 +684,8 @@ pub fn run() {
             clear_cache,
             cascade_uninstall,
             force_remove_mod,
-            get_dependents
+            get_dependents,
+            reindex_mods
         ])
         .run(tauri::generate_context!());
     if let Err(e) = result {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -379,7 +379,7 @@ async fn reindex_mods(state: tauri::State<'_, AppState>) -> Result<(usize, usize
     let db = state
         .db
         .lock()
-        .map_err(|e| AppError::LockPoisoned("Database lock poisoned".to_string()))?;
+        .map_err(|e| AppError::LockPoisoned(format!("Database lock poisoned: {}", e)))?;
     
     // Phase 1: Filesystem cleanup
     let mut files_removed = 0;
@@ -415,7 +415,6 @@ async fn reindex_mods(state: tauri::State<'_, AppState>) -> Result<(usize, usize
 
     // Phase 2: Database cleanup
     let installed_mods = db.get_installed_mods().map_err(|e| e.to_string())?;
-    let mut cleaned_entries = 0;
     let mut to_remove = Vec::new();
 
     for (index, installed_mod) in installed_mods.iter().enumerate() {
@@ -424,7 +423,7 @@ async fn reindex_mods(state: tauri::State<'_, AppState>) -> Result<(usize, usize
         }
     }
 
-    cleaned_entries = to_remove.len();
+    let cleaned_entries = to_remove.len();
     for &index in to_remove.iter().rev() {
         db.remove_installed_mod(&installed_mods[index].name)
             .map_err(|e| e.to_string())?;

--- a/src/components/WarningPopup.svelte
+++ b/src/components/WarningPopup.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
 	import { fade, scale } from "svelte/transition";
+    import { showWarningPopup } from "../stores/modStore";
 
 	export let visible: boolean = false;
 	export let message: string = "";
 	export let onConfirm: () => void;
 	export let onCancel: () => void;
+
+	function handleConfirm() {
+		onConfirm();
+		showWarningPopup.update((p) => ({ ...p, visible: false }));
+	}
+
+	function handleCancel() {
+		onCancel();
+		showWarningPopup.update((p) => ({ ...p, visible: false }));
+	}
 </script>
 
 {#if visible}
@@ -16,9 +27,10 @@
 			<h2>Warning</h2>
 			<p>{message}</p>
 			<div class="buttons">
-				<button class="cancel-button" on:click={onCancel}>Cancel</button
+				<button class="cancel-button" on:click={handleCancel}
+					>Cancel</button
 				>
-				<button class="confirm-button" on:click={onConfirm}
+				<button class="confirm-button" on:click={handleConfirm}
 					>Confirm</button
 				>
 			</div>

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -750,10 +750,7 @@
 	}
 
 	.mods-grid {
-		padding-top: 50px; /* Reduced from 60px since control is lower */
-
-		height: 100%;
-
+		height: 95%;
 		flex: 1;
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -13,7 +13,7 @@
 	} from "../../stores/modStore";
 	import { invoke } from "@tauri-apps/api/core";
 	import { addMessage } from "$lib/stores";
-    import UninstallDialog from "../../components/UninstallDialog.svelte";
+	import UninstallDialog from "../../components/UninstallDialog.svelte";
 
 	let currentSection = "mods";
 	// window.addEventListener("resize", () => {
@@ -35,8 +35,9 @@
 	let dependents: string[] = [];
 
 	async function handleRefresh() {
-		const installedMods: InstalledMod[] =
-			await invoke("get_installed_mods_from_db");
+		const installedMods: InstalledMod[] = await invoke(
+			"get_installed_mods_from_db",
+		);
 		installationStatus.set(
 			Object.fromEntries(
 				installedMods.map((mod: InstalledMod) => [mod.name, true]),
@@ -58,15 +59,6 @@
 		showRequiresPopup = true;
 	}
 
-	async function confirmReindex() {
-		try {
-			await invoke("refresh_mods_folder");
-			addMessage("Mods re-indexed successfully", "success");
-		} catch (error) {
-			addMessage("Failed to re-index mods: " + error, "error");
-		}
-		showWarningPopup.set(false);
-	}
 </script>
 
 <ShaderBackground />
@@ -125,14 +117,14 @@
 	/>
 
 	<WarningPopup
-		visible={$showWarningPopup}
-		message="Untracked mods detected! All mods in the Mods directory that are not tracked in the database will be deleted. Are you sure you want to proceed?"
-		onConfirm={confirmReindex}
-		onCancel={() => showWarningPopup.set(false)}
+		visible={$showWarningPopup.visible}
+		message={$showWarningPopup.message}
+		onConfirm={$showWarningPopup.onConfirm}
+		onCancel={$showWarningPopup.onCancel}
 	/>
 	<UninstallDialog
 		bind:show={showUninstallDialog}
-		targetMod={selectedMod.name}
+		modName={selectedMod.name}
 		modPath={selectedMod.path}
 		{dependents}
 		on:uninstalled={handleRefresh}

--- a/src/stores/modStore.ts
+++ b/src/stores/modStore.ts
@@ -65,8 +65,6 @@ if (typeof window !== 'undefined') {
 	});
 }
 
-export const showWarningPopup: Writable<boolean> = writable(false);
-
 export interface DependencyCheck {
 	steamodded: boolean;
 	talisman: boolean;
@@ -126,3 +124,19 @@ function createPersistentCategory() {
 }
 
 export const currentCategory = createPersistentCategory();
+
+
+export interface WarningPopupState {
+	visible: boolean;
+	message: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export const showWarningPopup = writable<WarningPopupState>({
+	visible: false,
+	message: "",
+	onConfirm: () => { },
+	onCancel: () => { }
+});
+


### PR DESCRIPTION
This pull request introduces several significant changes to the codebase, focusing on adding a new reindexing feature, enhancing the warning popup functionality, and making various UI adjustments. Below is a summary of the most important changes:

### Reindexing Feature:

* Added a new `reindex_mods` command to clean up the filesystem and database by removing untracked mod files and cleaning database entries for missing mods. (`src-tauri/src/lib.rs`)
* Integrated the `reindex_mods` command into the Tauri app's command list. (`src-tauri/src/lib.rs`)

### Warning Popup Enhancements:

* Updated `WarningPopup.svelte` to use the new `showWarningPopup` store for managing visibility and actions, and added `handleConfirm` and `handleCancel` functions to update the store state. (`src/components/WarningPopup.svelte`) [[1]](diffhunk://#diff-a53895dcc1b60a5edb1ca4972821a7b30a1689be5af15ec98911cdcebff917d7R3-R18) [[2]](diffhunk://#diff-a53895dcc1b60a5edb1ca4972821a7b30a1689be5af15ec98911cdcebff917d7L19-R33)
* Refactored `modStore.ts` to include a new `WarningPopupState` interface and updated `showWarningPopup` to use this interface. (`src/stores/modStore.ts`) [[1]](diffhunk://#diff-ceb9481d4a9134a98aa4ea64d8231c54e1a6778c30246b9c2b6b9b2e085b4530L68-L69) [[2]](diffhunk://#diff-ceb9481d4a9134a98aa4ea64d8231c54e1a6778c30246b9c2b6b9b2e085b4530R127-R142)

### UI Adjustments:

* Adjusted the height of the `.mods-grid` class in `Mods.svelte` to improve layout. (`src/components/viewblock/Mods.svelte`)
* Enhanced the `Settings.svelte` component to display reindexing statistics and updated button labels and descriptions for better clarity. (`src/components/viewblock/Settings.svelte`) [[1]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351R8-R83) [[2]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351R150-R175)

### Code Cleanup:

* Removed the redundant `confirmReindex` function and updated `WarningPopup` bindings in `main/+page.svelte` to use the new store-based approach. (`src/routes/main/+page.svelte`) [[1]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL38-R40) [[2]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL61-L69) [[3]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL128-R127)