### PR TITLE
add option to enable/disable background animation

### DIFF
--- a/src-tauri/bmm-lib/src/database.rs
+++ b/src-tauri/bmm-lib/src/database.rs
@@ -161,6 +161,28 @@ impl Database {
         Ok(())
     }
 
+    pub fn set_background_enabled(&self, enabled: bool) -> Result<(), AppError> {
+        let enabled: &str = if enabled { "enabled" } else { "disabled" };
+        self.conn.execute(
+            "INSERT OR REPLACE INTO settings (setting, value) VALUES ('background_enabled', ?1)",
+            [enabled],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_background_enabled(&self) -> Result<bool, AppError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT value FROM settings WHERE setting = 'background_enabled'")?;
+        let mut rows = stmt.query([])?;
+
+        if let Some(row) = rows.next()? {
+            Ok(row.get::<_, String>(0)? == "enabled")
+        } else {
+            Ok(false)
+        }
+    }
+
     fn enable_lovely_console(&self) -> Result<(), AppError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO settings (setting, value) VALUES ('lovely_console', 'enabled')",

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -14,7 +14,11 @@
 	} from "lucide-svelte";
 	import ModView from "./ModView.svelte";
 	import { tick } from "svelte";
-	import { SortOption, currentSort } from "../../stores/modStore";
+	import {
+		SortOption,
+		backgroundEnabled,
+		currentSort,
+	} from "../../stores/modStore";
 	import { ArrowUpDown } from "lucide-svelte";
 
 	import {
@@ -36,6 +40,7 @@
 	import SearchView from "./SearchView.svelte";
 	import { onMount } from "svelte";
 	import { writable } from "svelte/store";
+	import { addMessage } from "$lib/stores";
 
 	const loadingDots = writable(0);
 
@@ -562,6 +567,18 @@
 			}
 		});
 	}
+
+	onMount(async () => {
+		try {
+			let isBackgroundAnimationEnabled: boolean = await invoke(
+				"get_background_state",
+			);
+			backgroundEnabled.set(isBackgroundAnimationEnabled);
+		} catch (error) {
+			console.error("Failed to get background status:", error);
+			addMessage("Error fetching background animation status", "error");
+		}
+	});
 
 	// Add sort handler
 	function handleSortChange(event: Event) {

--- a/src/components/viewblock/Settings.svelte
+++ b/src/components/viewblock/Settings.svelte
@@ -4,11 +4,12 @@
 	import { addMessage } from "$lib/stores";
 	import { onMount } from "svelte";
 	import { invoke } from "@tauri-apps/api/core";
-	import { showWarningPopup } from "../../stores/modStore";
+	import { showWarningPopup, backgroundEnabled } from "../../stores/modStore";
 
 	let isReindexing = false;
 	let isClearingCache = false;
 	let isConsoleEnabled = false;
+	let isBackgroundAnimationEnabled = false;
 	let lastReindexStats = {
 		removedFiles: 0,
 		cleanedEntries: 0,
@@ -106,12 +107,36 @@
 			addMessage("Failed to update Lovely Console status", "error");
 		}
 	}
+
+	async function handleBackgroundAnimationChange() {
+		const newValue = !isBackgroundAnimationEnabled;
+
+		// Optimistic UI update
+		backgroundEnabled.set(newValue);
+
+		try {
+			await invoke("set_background_state", { enabled: newValue });
+			isBackgroundAnimationEnabled = newValue;
+		} catch (error) {
+			// Rollback on failure
+			backgroundEnabled.set(!newValue);
+			isBackgroundAnimationEnabled = !newValue;
+		}
+	}
+
 	onMount(async () => {
 		try {
 			isConsoleEnabled = await invoke("get_lovely_console_status");
 		} catch (error) {
 			console.error("Failed to get console status:", error);
 			addMessage("Error fetching Lovely Console status", "error");
+		}
+		try {
+			isBackgroundAnimationEnabled = await invoke("get_background_state");
+			backgroundEnabled.set(isBackgroundAnimationEnabled);
+		} catch (error) {
+			console.error("Failed to get background status:", error);
+			addMessage("Error fetching background animation status", "error");
 		}
 	});
 </script>
@@ -168,13 +193,30 @@
 				</div>
 			{/if}
 
-			<p class="description">
+			<p class="description-small">
 				Performs full consistency check between installed mods and
 				database. Will remove:
 				<br />• Untracked files/directories in Mods folder
 				<br />• Database entries for missing mod installations
 			</p>
 		</div>
+		<h3>Appearance</h3>
+		<div class="console-settings">
+			<span class="label-text">Enable Background Animation</span>
+			<div class="switch-container">
+				<label class="switch">
+					<input
+						type="checkbox"
+						checked={isBackgroundAnimationEnabled}
+						on:change={handleBackgroundAnimationChange}
+					/> <span class="slider"></span>
+				</label>
+			</div>
+		</div>
+		<p class="description-small">
+			Enable or disable the animated background. Disabling may improve
+			performance on low-end devices.
+		</p>
 
 		<h3>Developer Options</h3>
 		<div class="console-settings">
@@ -285,6 +327,15 @@
 		max-width: 400px;
 		line-height: 1.4;
 	} /* Custom Toggle Switch Styles */
+	.description-small {
+		/* color a bit grayer but still light */
+		color: #c4c2c2;
+		font-size: 1.1rem;
+		margin-top: 0.5rem;
+		opacity: 0.9;
+		max-width: 400px;
+		line-height: 1.4;
+	}
 	.console-settings {
 		display: flex;
 		align-items: center;
@@ -378,6 +429,10 @@
 		}
 		.description {
 			font-size: 1.1rem;
+			max-width: 100%;
+		}
+		.description-small {
+			font-size: 1rem;
 			max-width: 100%;
 		}
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import { blur } from "svelte/transition";
-    import MessageStack from "../components/MessageStack.svelte";
+	import MessageStack from "../components/MessageStack.svelte";
+	import { backgroundEnabled } from "../stores/modStore"; // Add this import
 
 	export let data;
 </script>
 
 <MessageStack />
-<div class="layout-container">
+<div
+	class="layout-container"
+	style:--gradient-opacity={$backgroundEnabled ? 0 : 1}
+>
 	{#key data.url}
 		<div
 			in:blur={{ duration: 300, delay: 150 }}
@@ -27,8 +31,34 @@
 		left: 0;
 	}
 
+	.layout-container::before {
+		content: "";
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		opacity: var(--gradient-opacity, 1);
+		transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+		background: linear-gradient(
+				145deg,
+				rgba(97, 11, 15, 0.95) 0%,
+				rgba(165, 25, 31, 0.9) 30%,
+				rgba(194, 63, 55, 0.85) 70%,
+				rgba(140, 20, 31, 0.95) 100%
+			),
+			linear-gradient(
+				45deg,
+				rgba(0, 0, 0, 0.15) 0%,
+				rgba(50, 0, 0, 0.2) 100%
+			);
+		background-blend-mode: multiply;
+		z-index: -1;
+	}
+
 	.page-content {
 		width: 100%;
 		height: 100%;
+		position: relative;
 	}
 </style>

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -7,6 +7,7 @@
 	import RequiresPopup from "../../components/RequiresPopup.svelte";
 	import WarningPopup from "../../components/WarningPopup.svelte";
 	import type { DependencyCheck, InstalledMod } from "../../stores/modStore";
+	import { backgroundEnabled } from "../../stores/modStore";
 	import {
 		installationStatus,
 		showWarningPopup,
@@ -14,6 +15,7 @@
 	import { invoke } from "@tauri-apps/api/core";
 	import { addMessage } from "$lib/stores";
 	import UninstallDialog from "../../components/UninstallDialog.svelte";
+	import { onMount } from "svelte";
 
 	let currentSection = "mods";
 	// window.addEventListener("resize", () => {
@@ -59,9 +61,15 @@
 		showRequiresPopup = true;
 	}
 
+	onMount(() => {
+		handleRefresh();
+	});
 </script>
 
-<ShaderBackground />
+{#if $backgroundEnabled}
+	<ShaderBackground />
+{/if}
+
 <div class="main-page">
 	<header>
 		<div class="header-content">

--- a/src/stores/modStore.ts
+++ b/src/stores/modStore.ts
@@ -22,6 +22,8 @@ export enum SortOption {
 	LastUpdatedDesc = "updated_desc"
 }
 
+export const backgroundEnabled = writable(false);
+
 export const currentSort = writable<SortOption>(SortOption.NameAsc);
 
 export interface UninstallDialogState {


### PR DESCRIPTION
This pull request introduces a feature to enable or disable background animations in the application. The changes span across multiple files, adding new functions to manage the background animation state and updating the UI to reflect this new setting.

### Database and Backend Changes:
* Added `set_background_enabled` and `get_background_enabled` functions to manage the background animation state in the database (`src-tauri/bmm-lib/src/database.rs`).
* Introduced `get_background_state` and `set_background_state` commands to interact with the new database functions (`src-tauri/src/lib.rs`). [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR566-R577) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL687-R701)

### Frontend Changes:
* Updated `Mods.svelte` to import and use the new `backgroundEnabled` store, and fetch the background state on mount (`src/components/viewblock/Mods.svelte`). [[1]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL17-R21) [[2]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR43) [[3]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR571-R582)
* Modified `Settings.svelte` to include a new toggle switch for enabling/disabling background animations and handle its state (`src/components/viewblock/Settings.svelte`). [[1]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351L7-R12) [[2]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351R110-R140) [[3]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351L171-R219) [[4]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351R330-R338) [[5]](diffhunk://#diff-8767bf5459218dbed5fc809b8581cea278ed2224bcff2d03a16afdbe10868351R434-R437)
* Updated `+layout.svelte` to conditionally apply a gradient overlay based on the `backgroundEnabled` state (`src/routes/+layout.svelte`). [[1]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR4-R13) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR34-R62)
* Added the `backgroundEnabled` store to `main/+page.svelte` and conditionally rendered the `ShaderBackground` component based on its state (`src/routes/main/+page.svelte`). [[1]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR10-R18) [[2]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR64-R72)

### Store Changes:
* Added `backgroundEnabled` writable store to manage the state of background animations (`src/stores/modStore.ts`).