### PR TITLE
Set update to newest

### DIFF
--- a/src/components/viewblock/ModView.svelte
+++ b/src/components/viewblock/ModView.svelte
@@ -61,7 +61,7 @@
 	let installedMods: InstalledMod[] = [];
 	let steamoddedVersions: string[] = [];
 	let talismanVersions: string[] = [];
-	let selectedVersion: string = "";
+	let selectedVersion: string = "newest";
 	let loadingVersions = false;
 	let versionLoadStarted = false;
 	let prevModTitle = "";
@@ -83,6 +83,7 @@
 				Date.now() - cached[1] * 1000 < VERSION_CACHE_DURATION
 			) {
 				steamoddedVersions = cached[0];
+				selectedVersion = "newest"; // Force "newest" as default
 				if (steamoddedVersions.length > 0) {
 					selectedVersion = steamoddedVersions[0];
 				}
@@ -97,9 +98,11 @@
 		try {
 			const versions: string[] = await invoke("get_steamodded_versions");
 			steamoddedVersions = versions;
-			if (versions.length > 0) {
-				selectedVersion = versions[0];
-			}
+			//
+			// if (versions.length > 0) {
+			// 	selectedVersion = versions[0];
+			// }
+			selectedVersion = "newest"; // Force "newest" as default
 
 			// Update cache
 			cachedVersions.update((c) => ({ ...c, steamodded: versions }));
@@ -501,7 +504,7 @@
 									bind:value={selectedVersion}
 									disabled={$loadingStates[mod.title]}
 								>
-									<option value="newest"
+									<option value="newest" selected
 										>latest (could be unstable)</option
 									>
 									{#each talismanVersions as version}


### PR DESCRIPTION
This pull request focuses on setting the default selected version to "newest" in the `ModView.svelte` component. The most important changes include updating the default value for `selectedVersion` and ensuring that "newest" is selected by default in various parts of the code.

Changes to default version selection:

* [`src/components/viewblock/ModView.svelte`](diffhunk://#diff-3ef7db5f7bd6ad5282fdb2f7b73543c92bd3e2fdb0a6739616762e10b733cf74L64-R64): Changed the initialization of `selectedVersion` to "newest".
* [`src/components/viewblock/ModView.svelte`](diffhunk://#diff-3ef7db5f7bd6ad5282fdb2f7b73543c92bd3e2fdb0a6739616762e10b733cf74R86): Forced "newest" as the default selection when loading cached versions.
* [`src/components/viewblock/ModView.svelte`](diffhunk://#diff-3ef7db5f7bd6ad5282fdb2f7b73543c92bd3e2fdb0a6739616762e10b733cf74L100-R105): Commented out the previous logic for setting `selectedVersion` and enforced "newest" as the default when fetching new versions.
* [`src/components/viewblock/ModView.svelte`](diffhunk://#diff-3ef7db5f7bd6ad5282fdb2f7b73543c92bd3e2fdb0a6739616762e10b733cf74L504-R507): Set the "newest" option as selected in the dropdown menu.