### PR TITLE
Implemented a way which installs the latest release for Steamodded

### DIFF
--- a/src-tauri/bmm-lib/src/smods_installer.rs
+++ b/src-tauri/bmm-lib/src/smods_installer.rs
@@ -64,7 +64,7 @@ struct ReleaseAsset {
 }
 pub struct ModInstaller {
     client: reqwest::Client,
-    mod_type: ModType,
+    pub mod_type: ModType,
 }
 
 impl ModInstaller {
@@ -107,6 +107,11 @@ impl ModInstaller {
         // dbg!(&mod_path);
 
         Ok(mod_path)
+    }
+
+    pub async fn get_latest_release(&self) -> Result<String> {
+        let versions = self.get_available_versions().await?;
+        Ok(versions[0].clone())
     }
 
     pub async fn get_available_versions(&self) -> Result<Vec<String>> {


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the mod management system. The most important changes are the addition of new methods for fetching the latest release versions, filtering out self-references in dependent mods, and enhancing the `ModCard` component to handle specific mod installation logic.

Enhancements to mod management:

* [`src-tauri/bmm-lib/src/smods_installer.rs`](diffhunk://#diff-e7cacfb4b06924d254eb0296b2b90580fc458d4720543291da6c40adec1e361eL67-R67): Added a new public method `get_latest_release` to `ModInstaller` to fetch the latest release version. Also, made the `mod_type` field public. [[1]](diffhunk://#diff-e7cacfb4b06924d254eb0296b2b90580fc458d4720543291da6c40adec1e361eL67-R67) [[2]](diffhunk://#diff-e7cacfb4b06924d254eb0296b2b90580fc458d4720543291da6c40adec1e361eR112-R116)

Filtering self-references in dependent mods:

* [`src-tauri/src/lib.rs`](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL650-R658): Updated the `get_dependents` and `remove_installed_mod` functions to filter out self-references from the list of dependents. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL650-R658) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL697-R717)

Fetching and installing the latest release:

* [`src-tauri/src/lib.rs`](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR784-R821): Added a new command `get_latest_steamodded_release` to fetch the latest release URL for the `Steamodded` mod, using cached versions if available. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR784-R821) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL924-R978)

Enhancements to `ModCard` component:

* [`src/components/viewblock/ModCard.svelte`](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4R9-R70): Modified the `installMod` function to handle the installation of the latest `Steamodded` release by invoking the new command. Added helper functions `fetchAndInstallLatestSteamodded` and `installModFromURL`. [[1]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4R9-R70) [[2]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4L46) [[3]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4L55-R98) [[4]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4L89-R125) [[5]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4L108) [[6]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4L265)