### PR TITLE
70 feat mod updating version display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balatro-mod-manager",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A mod manager for Balatro - easily install and manage mods for the popular roguelike deckbuilding game",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "balatro-mod-manager"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "assert_fs",
  "base64 0.22.1",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "bmm-lib"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["gaming", "mods", "balatro", "manager", "tauri"]
 categories = ["games", "development-tools", "gui"]
 readme = "README.md"
 repository = "https://github.com/skyline69/balatro-mod-manager"
+publish = false
 
 
 [lib]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "balatro-mod-manager"
-version = "0.1.8"
+version = "0.1.9"
 description = "A mod manager for Balatro - easily install and manage mods for the popular roguelike deckbuilding game"
 authors = ["skyline69<67526259+skyline69@users.noreply.github.com>"]
 edition = "2021"

--- a/src-tauri/bmm-lib/Cargo.lock
+++ b/src-tauri/bmm-lib/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "bmm-lib"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src-tauri/bmm-lib/Cargo.toml
+++ b/src-tauri/bmm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bmm-lib"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/bmm-lib/src/cache.rs
+++ b/src-tauri/bmm-lib/src/cache.rs
@@ -29,8 +29,6 @@ pub struct Mod {
     pub title: String,
     pub description: String,
     pub image: String,
-    // #[serde(rename = "lastUpdated")]
-    // pub last_updated: String,
     #[serde(rename = "categories")]
     pub categories: Vec<Category>,
     #[serde(rename = "colors")]
@@ -45,6 +43,7 @@ pub struct Mod {
     #[serde(rename = "downloadURL")]
     pub download_url: String,
     pub folderName: Option<String>,
+    pub version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -329,6 +328,7 @@ mod tests {
                 repo: "test/test".into(),
                 download_url: "https://test.com/mod.zip".into(),
                 folderName: None,
+                version: None,
             };
 
             save_cache(&[test_mod.clone()])?;

--- a/src-tauri/src/github_repo.rs
+++ b/src-tauri/src/github_repo.rs
@@ -6,8 +6,8 @@ use std::io::Write;
 use std::path::PathBuf;
 //
 
-// const CURRENT_BRANCH: &str = "80-suggestion-allow-specifying-mod-folder-name";
-const CURRENT_BRANCH: &str = "main";
+// const CURRENT_BRANCH: &str = "main";
+const CURRENT_BRANCH: &str = "98-implement-version-parameter";
 
 // Helper function to extract repo owner and name from URL
 pub fn parse_github_url(url: &str) -> Option<(String, String)> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,8 @@ pub struct ModMeta {
     pub folder_name: String,
     #[serde(default)]
     pub version: String,
+    #[serde(rename = "automatic-version-check", default)]
+    automatic_version_check: bool,
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,8 @@ pub struct ModMeta {
     pub download_url: Option<String>,
     #[serde(rename = "folderName", default)]
     pub folder_name: String,
+    #[serde(default)]
+    pub version: String,
 }
 
 #[tauri::command]
@@ -75,6 +77,43 @@ async fn check_balatro_running() -> bool {
 #[tauri::command]
 async fn save_versions_cache(mod_type: String, versions: Vec<String>) -> Result<(), String> {
     map_error(cache::save_versions_cache(&mod_type, &versions))
+}
+
+#[tauri::command]
+async fn mod_update_available(
+    mod_name: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<bool, String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    let last_installed_version = db
+        .get_last_installed_version(&mod_name)
+        .map_err(|e| e.to_string())?;
+
+    // If no version is installed, we can't determine if an update is available
+    if last_installed_version.is_empty() {
+        return Ok(false);
+    }
+
+    // Try to get the cached mods
+    let cached_mods = match crate::cache::load_cache().map_err(|e| e.to_string())? {
+        Some((mods, _)) => mods,
+        None => return Ok(false), // No cache available
+    };
+
+    // Look for the mod in the cache by matching either title or folderName
+    for cached_mod in cached_mods {
+        if cached_mod.title == mod_name || (cached_mod.folderName.as_ref() == Some(&mod_name)) {
+            // If we found a match and it has a version, compare versions
+            if let Some(remote_version) = cached_mod.version {
+                // If versions are different, consider an update available
+                return Ok(remote_version != last_installed_version);
+            }
+            break; // Found the mod but it has no version info
+        }
+    }
+
+    // No update found or couldn't determine
+    Ok(false)
 }
 
 #[tauri::command]
@@ -575,9 +614,17 @@ async fn add_installed_mod(
     name: String,
     path: String,
     dependencies: Vec<String>,
+    current_version: String,
 ) -> Result<(), String> {
     let db = state.db.lock().map_err(|e| e.to_string())?;
-    map_error(db.add_installed_mod(&name, &path, &dependencies))
+    let current_version = {
+        if current_version.is_empty() {
+            None
+        } else {
+            Some(current_version)
+        }
+    };
+    map_error(db.add_installed_mod(&name, &path, &dependencies, current_version))
 }
 
 #[tauri::command]
@@ -981,12 +1028,12 @@ pub fn run() {
             list_directories,
             read_json_file,
             read_text_file,
-            // get_mod_timestamps,
             get_mod_thumbnail,
             get_discord_rpc_status,
             set_discord_rpc_status,
             get_latest_steamodded_release,
-            set_discord_rpc_status
+            set_discord_rpc_status,
+            mod_update_available,
         ])
         .run(tauri::generate_context!());
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Balatro Mod Manager",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.balatro-mod-manager.app",
   "build": {
     "beforeDevCommand": "deno task dev",

--- a/src/components/viewblock/About.svelte
+++ b/src/components/viewblock/About.svelte
@@ -70,7 +70,7 @@
 				</button>
 			</div>
 	
-			<p id="versiontext">Current version: v0.1.8</p>
+			<p id="versiontext">Current version: v0.1.9</p>
 		</div>
 	
 		<div class="profile-section">

--- a/src/components/viewblock/ModCard.svelte
+++ b/src/components/viewblock/ModCard.svelte
@@ -358,6 +358,15 @@
 		transition: all 0.2s ease;
 	}
 
+	.delete-button:hover {
+		background: #d4524a;
+		transform: translateY(-2px);
+	}
+
+	.delete-button:active {
+		transform: translateY(1px);
+	}
+
 	.download-button:disabled,
 	.update-button:disabled {
 		opacity: 0.8;

--- a/src/components/viewblock/ModCard.svelte
+++ b/src/components/viewblock/ModCard.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import type { Mod } from "../../stores/modStore";
-	import { Download, Trash2 } from "lucide-svelte";
+	import { Download, Trash2, RefreshCw } from "lucide-svelte";
 	import {
 		installationStatus,
 		loadingStates2 as loadingStates,
 	} from "../../stores/modStore";
 	import { stripMarkdown, truncateText } from "../../utils/helpers";
 	import { invoke } from "@tauri-apps/api/core";
+	import { writable } from "svelte/store";
+
+	// Store to track which mods have updates available
+	const updateAvailable = writable<Record<string, boolean>>({});
 
 	interface Props {
 		mod: Mod;
@@ -17,8 +21,38 @@
 
 	let { mod, oninstallclick, onuninstallclick, onmodclick }: Props = $props();
 
+	// Check if an update is available when component mounts
+	$effect(() => {
+		checkForUpdate(mod.title);
+	});
+
+	async function checkForUpdate(modName: string) {
+		try {
+			const hasUpdate = await invoke<boolean>("mod_update_available", {
+				modName,
+			});
+
+			updateAvailable.update((updates) => ({
+				...updates,
+				[modName]: hasUpdate,
+			}));
+		} catch (error) {
+			console.error("Failed to check for updates:", error);
+		}
+	}
+
 	function installMod(e: Event) {
 		e.stopPropagation();
+		if (mod.title.toLowerCase() === "steamodded") {
+			fetchAndInstallLatestSteamodded();
+		} else if (oninstallclick) {
+			oninstallclick(mod);
+		}
+	}
+
+	function updateMod(e: Event) {
+		e.stopPropagation();
+		// Reuse the install logic but for updating
 		if (mod.title.toLowerCase() === "steamodded") {
 			fetchAndInstallLatestSteamodded();
 		} else if (oninstallclick) {
@@ -67,29 +101,22 @@
 				name: mod.title,
 				path: installedPath,
 				dependencies: mod.requires_steamodded ? ["Steamodded"] : [],
+				currentVersion: mod.version || "",
 			});
 
 			installationStatus.update((s) => ({ ...s, [mod.title]: true }));
+
+			// After installing/updating, reset update status
+			updateAvailable.update((updates) => ({
+				...updates,
+				[mod.title]: false,
+			}));
 		} catch (error) {
 			console.error("Failed to install mod:", error);
 		} finally {
 			loadingStates.update((s) => ({ ...s, [mod.title]: false }));
 		}
 	}
-
-	/* Later, for CSS
-		.tag {
-			display: flex;
-			align-items: center;
-			position: relative;
-			gap: 0.2rem;
-			padding: 0.15rem 0.3rem;
-			background: rgba(0, 0, 0, 0.7);
-			border-radius: 4px;
-			font-size: 0.9rem;
-			color: #f4eee0;
-		}
-	*/
 </script>
 
 <div
@@ -118,20 +145,37 @@
 	</div>
 
 	<div class="button-container">
-		<button
-			class="download-button"
-			class:installed={$installationStatus[mod.title]}
-			disabled={$installationStatus[mod.title] ||
-				$loadingStates[mod.title]}
-			onclick={installMod}
-		>
-			{#if $loadingStates[mod.title]}
-				<div class="spinner"></div>
-			{:else}
-				<Download size={18} />
-				{$installationStatus[mod.title] ? "Installed" : "Download"}
-			{/if}
-		</button>
+		{#if $installationStatus[mod.title] && $updateAvailable[mod.title]}
+			<!-- Update button (when installed and update available) -->
+			<button
+				class="update-button"
+				onclick={updateMod}
+				disabled={$loadingStates[mod.title]}
+			>
+				{#if $loadingStates[mod.title]}
+					<div class="spinner"></div>
+				{:else}
+					<RefreshCw size={18} />
+					Update Mod
+				{/if}
+			</button>
+		{:else}
+			<!-- Regular download/installed button -->
+			<button
+				class="download-button"
+				class:installed={$installationStatus[mod.title]}
+				disabled={$installationStatus[mod.title] ||
+					$loadingStates[mod.title]}
+				onclick={installMod}
+			>
+				{#if $loadingStates[mod.title]}
+					<div class="spinner"></div>
+				{:else}
+					<Download size={18} />
+					{$installationStatus[mod.title] ? "Installed" : "Download"}
+				{/if}
+			</button>
+		{/if}
 
 		{#if $installationStatus[mod.title]}
 			<button
@@ -263,6 +307,33 @@
 		transition: all 0.2s ease;
 	}
 
+	.update-button {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		background: #3498db; /* Bright blue color */
+		color: #f4eee0;
+		border: none;
+		outline: #2980b9 solid 2px; /* Darker blue for outline */
+		border-radius: 4px;
+		font-family: "M6X11", sans-serif;
+		font-size: 1rem;
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.update-button:hover {
+		background: #5dade2; /* Lighter blue on hover */
+		transform: translateY(-2px);
+	}
+
+	.update-button:active {
+		transform: translateY(1px);
+	}
+
 	.download-button:hover:not(.installed) {
 		background: #63b897;
 		transform: translateY(-2px);
@@ -292,7 +363,8 @@
 		transition: all 0.2s ease;
 	}
 
-	.download-button:disabled {
+	.download-button:disabled,
+	.update-button:disabled {
 		opacity: 0.8;
 		cursor: not-allowed;
 	}
@@ -300,6 +372,24 @@
 	@media (max-width: 1160px) {
 		.mod-card {
 			width: 100%;
+		}
+	}
+
+	.spinner {
+		border: 3px solid rgba(255, 255, 255, 0.3);
+		border-top: 3px solid #ffffff;
+		border-radius: 50%;
+		width: 20px;
+		height: 20px;
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
 		}
 	}
 </style>

--- a/src/components/viewblock/ModCard.svelte
+++ b/src/components/viewblock/ModCard.svelte
@@ -289,24 +289,7 @@
 		width: calc(100% - 2rem);
 	}
 
-	.download-button {
-		flex: 1;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.5rem;
-		padding: 0.75rem;
-		background: #56a786;
-		color: #f4eee0;
-		border: none;
-		outline: #459373 solid 2px;
-		border-radius: 4px;
-		font-family: "M6X11", sans-serif;
-		font-size: 1rem;
-		cursor: pointer;
-		transition: all 0.2s ease;
-	}
-
+	.download-button,
 	.update-button {
 		flex: 1;
 		display: flex;
@@ -314,15 +297,27 @@
 		justify-content: center;
 		gap: 0.5rem;
 		padding: 0.75rem;
-		background: #3498db; /* Bright blue color */
-		color: #f4eee0;
 		border: none;
-		outline: #2980b9 solid 2px; /* Darker blue for outline */
 		border-radius: 4px;
 		font-family: "M6X11", sans-serif;
 		font-size: 1rem;
 		cursor: pointer;
 		transition: all 0.2s ease;
+		/* Add these properties to prevent resizing */
+		min-height: 42px; /* Set explicit height */
+		position: relative; /* For absolute positioning of spinner */
+	}
+
+	.download-button {
+		background: #56a786;
+		color: #f4eee0;
+		outline: #459373 solid 2px;
+	}
+
+	.update-button {
+		background: #3498db;
+		color: #f4eee0;
+		outline: #2980b9 solid 2px;
 	}
 
 	.update-button:hover {
@@ -376,12 +371,15 @@
 	}
 
 	.spinner {
-		border: 3px solid rgba(255, 255, 255, 0.3);
-		border-top: 3px solid #ffffff;
+		border: 2px solid rgba(255, 255, 255, 0.3);
+		border-top: 2px solid #ffffff;
 		border-radius: 50%;
-		width: 20px;
-		height: 20px;
+		width: 16px;
+		height: 16px;
 		animation: spin 1s linear infinite;
+		/* Center the spinner while maintaining button size */
+		margin: 0 auto;
+		display: inline-block;
 	}
 
 	@keyframes spin {

--- a/src/components/viewblock/ModView.svelte
+++ b/src/components/viewblock/ModView.svelte
@@ -982,23 +982,7 @@
 		margin: 1rem 0;
 	}
 
-	.download-button {
-		flex: 1;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.5rem;
-		padding: 1rem;
-		background: #56a786;
-		color: #f4eee0;
-		border: none;
-		border-radius: 6px;
-		font-size: 1rem;
-		cursor: pointer;
-		transition: all 0.2s ease;
-		font-family: "M6X11", sans-serif;
-	}
-
+	.download-button,
 	.update-button {
 		flex: 1;
 		display: flex;
@@ -1006,14 +990,24 @@
 		justify-content: center;
 		gap: 0.5rem;
 		padding: 1rem;
-		background: #3498db; /* Bright blue color */
-		color: #f4eee0;
 		border: none;
 		border-radius: 6px;
 		font-size: 1rem;
 		cursor: pointer;
 		transition: all 0.2s ease;
 		font-family: "M6X11", sans-serif;
+		/* Fixed height to prevent resizing */
+		min-height: 48px;
+	}
+
+	.download-button {
+		background: #56a786;
+		color: #f4eee0;
+	}
+
+	.update-button {
+		background: #3498db; /* Bright blue color */
+		color: #f4eee0;
 	}
 
 	.update-button:hover:not(:disabled) {
@@ -1026,11 +1020,11 @@
 	}
 
 	.spinner {
-		border: 3px solid rgba(255, 255, 255, 0.3);
-		border-top: 3px solid #ffffff;
+		border: 2px solid rgba(255, 255, 255, 0.3);
+		border-top: 2px solid #ffffff;
 		border-radius: 50%;
-		width: 20px;
-		height: 20px;
+		width: 16px;
+		height: 16px;
 		animation: spin 1s linear infinite;
 	}
 

--- a/src/components/viewblock/ModView.svelte
+++ b/src/components/viewblock/ModView.svelte
@@ -8,6 +8,7 @@
 		ArrowLeft,
 		Github,
 		X,
+		RefreshCw,
 	} from "lucide-svelte";
 	import { onMount, onDestroy } from "svelte";
 	import { open } from "@tauri-apps/plugin-shell";
@@ -24,6 +25,10 @@
 	import { cachedVersions } from "../../stores/modStore";
 	import { modsStore } from "../../stores/modStore";
 	import { untrack } from "svelte";
+	import { writable } from "svelte/store";
+
+	// Store to track which mods have updates available
+	const updateAvailable = writable<Record<string, boolean>>({});
 
 	const VERSION_CACHE_DURATION = 60 * 60 * 1000;
 
@@ -50,6 +55,7 @@
 	let selectedVersion = $state("newest");
 	let loadingVersions = $state(false);
 	let renderedDescription = $state("");
+	let isCheckingForUpdates = $state(false);
 
 	let versionLoadStarted = false;
 	let prevModTitle = "";
@@ -70,6 +76,27 @@
 	interface internalModLinkData {
 		isMod: boolean;
 		modName: string;
+	}
+
+	// Check if an update is available for the current mod
+	async function checkForUpdate(modName: string) {
+		if (isCheckingForUpdates) return;
+
+		isCheckingForUpdates = true;
+		try {
+			const hasUpdate = await invoke<boolean>("mod_update_available", {
+				modName,
+			});
+
+			updateAvailable.update((updates) => ({
+				...updates,
+				[modName]: hasUpdate,
+			}));
+		} catch (error) {
+			console.error("Failed to check for updates:", error);
+		} finally {
+			isCheckingForUpdates = false;
+		}
 	}
 
 	function isInternalModLink(url: string): internalModLinkData {
@@ -295,13 +322,19 @@
 					...s,
 					[mod.title]: false,
 				}));
+
+				// Reset update status for this mod
+				updateAvailable.update((updates) => ({
+					...updates,
+					[mod.title]: false,
+				}));
 			}
 		} catch (e) {
 			console.error("Failed to uninstall mod:", e);
 		}
 	};
 
-	const installMod = async (mod: Mod) => {
+	const installMod = async (mod: Mod, isUpdate = false) => {
 		// Check dependencies first before doing anything else
 		if (mod.requires_steamodded || mod.requires_talisman) {
 			// Check Steamodded if required
@@ -319,10 +352,11 @@
 				: true;
 
 			// If any dependency is missing, show the RequiresPopup
-
+			// But skip this check if it's an update, as dependencies should already be installed
 			if (
-				(mod.requires_steamodded && !steamoddedInstalled) ||
-				(mod.requires_talisman && !talismanInstalled)
+				!isUpdate &&
+				((mod.requires_steamodded && !steamoddedInstalled) ||
+					(mod.requires_talisman && !talismanInstalled))
 			) {
 				// Call the handler with the appropriate requirements
 				onCheckDependencies?.({
@@ -366,9 +400,16 @@
 					name: mod.title,
 					path: installedPath,
 					dependencies,
+					currentVersion: mod.version || "",
 				});
 				await getAllInstalledMods();
 				installationStatus.update((s) => ({ ...s, [mod.title]: true }));
+
+				// Reset update status after successful update
+				updateAvailable.update((updates) => ({
+					...updates,
+					[mod.title]: false,
+				}));
 			} else if (mod.title.toLowerCase() === "talisman") {
 				let installedPath;
 				if (selectedVersion === "newest") {
@@ -394,9 +435,16 @@
 					name: mod.title,
 					path: installedPath,
 					dependencies: [],
+					currentVersion: mod.version || "",
 				});
 				await getAllInstalledMods();
 				installationStatus.update((s) => ({ ...s, [mod.title]: true }));
+
+				// Reset update status after successful update
+				updateAvailable.update((updates) => ({
+					...updates,
+					[mod.title]: false,
+				}));
 			} else {
 				const installedPath = await invoke<string>("install_mod", {
 					url: mod.downloadURL,
@@ -406,15 +454,30 @@
 					name: mod.title,
 					path: installedPath,
 					dependencies,
+					currentVersion: mod.version || "",
 				});
 				await getAllInstalledMods();
 				installationStatus.update((s) => ({ ...s, [mod.title]: true }));
+
+				// Reset update status after successful update
+				updateAvailable.update((updates) => ({
+					...updates,
+					[mod.title]: false,
+				}));
 			}
 		} catch (e) {
-			console.error("Failed to install mod:", e);
+			console.error(
+				`Failed to ${isUpdate ? "update" : "install"} mod:`,
+				e,
+			);
 		} finally {
 			loadingStates.update((s) => ({ ...s, [mod.title]: false }));
 		}
+	};
+
+	// Function to handle updating the mod
+	const updateMod = async (mod: Mod) => {
+		await installMod(mod, true);
 	};
 
 	function handleMarkdownClick(event: MouseEvent | KeyboardEvent) {
@@ -530,6 +593,11 @@
 				...s,
 				[mod.title]: status,
 			}));
+
+			// If the mod is installed, check for updates
+			if (status) {
+				checkForUpdate(mod.title);
+			}
 		}, 0);
 
 		return status;
@@ -717,22 +785,40 @@
 					{/if}
 				</div>
 				<div class="button-container">
-					<button
-						class="download-button"
-						class:installed={$installationStatus[mod.title]}
-						disabled={$installationStatus[mod.title] ||
-							$loadingStates[mod.title]}
-						onclick={() => installMod(mod)}
-					>
-						{#if $loadingStates[mod.title]}
-							<div class="spinner"></div>
-						{:else}
-							<Download size={18} />
-							{$installationStatus[mod.title]
-								? "Installed"
-								: "Download"}
-						{/if}
-					</button>
+					{#if $installationStatus[mod.title] && $updateAvailable[mod.title]}
+						<!-- Update button (when installed and update available) -->
+						<button
+							class="update-button"
+							onclick={() => updateMod(mod)}
+							disabled={$loadingStates[mod.title]}
+						>
+							{#if $loadingStates[mod.title]}
+								<div class="spinner"></div>
+							{:else}
+								<RefreshCw size={18} />
+								Update Mod
+							{/if}
+						</button>
+					{:else}
+						<!-- Regular download/installed button -->
+						<button
+							class="download-button"
+							class:installed={$installationStatus[mod.title]}
+							disabled={$installationStatus[mod.title] ||
+								$loadingStates[mod.title]}
+							onclick={() => installMod(mod)}
+						>
+							{#if $loadingStates[mod.title]}
+								<div class="spinner"></div>
+							{:else}
+								<Download size={18} />
+								{$installationStatus[mod.title]
+									? "Installed"
+									: "Download"}
+							{/if}
+						</button>
+					{/if}
+
 					{#if $installationStatus[mod.title]}
 						<button
 							class="delete-button"
@@ -911,6 +997,50 @@
 		cursor: pointer;
 		transition: all 0.2s ease;
 		font-family: "M6X11", sans-serif;
+	}
+
+	.update-button {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		padding: 1rem;
+		background: #3498db; /* Bright blue color */
+		color: #f4eee0;
+		border: none;
+		border-radius: 6px;
+		font-size: 1rem;
+		cursor: pointer;
+		transition: all 0.2s ease;
+		font-family: "M6X11", sans-serif;
+	}
+
+	.update-button:hover:not(:disabled) {
+		background: #5dade2; /* Lighter blue on hover */
+		transform: translateY(-2px);
+	}
+
+	.update-button:active:not(:disabled) {
+		transform: translateY(1px);
+	}
+
+	.spinner {
+		border: 3px solid rgba(255, 255, 255, 0.3);
+		border-top: 3px solid #ffffff;
+		border-radius: 50%;
+		width: 20px;
+		height: 20px;
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
 	}
 
 	.download-button:hover:not(.installed) {
@@ -1257,7 +1387,8 @@
 		}
 	}
 
-	.download-button:disabled {
+	.download-button:disabled,
+	.update-button:disabled {
 		opacity: 0.8;
 		cursor: not-allowed;
 	}

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -236,6 +236,7 @@
 				name: mod.title,
 				path: installedPath,
 				dependencies,
+				currentVersion: mod.version || "",
 			});
 
 			installationStatus.update((s) => ({ ...s, [mod.title]: true }));
@@ -267,6 +268,7 @@
 		repo: string;
 		downloadURL?: string;
 		folderName?: string;
+		version?: string;
 	}
 
 	const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes
@@ -399,6 +401,7 @@
 								repo: meta.repo,
 								downloadURL: meta.downloadURL || "",
 								folderName: meta.folderName,
+								version: meta.version,
 								installed: false,
 							} as Mod;
 						} catch (error) {

--- a/src/components/viewblock/SearchView.svelte
+++ b/src/components/viewblock/SearchView.svelte
@@ -150,6 +150,7 @@
 				name: mod.title,
 				path: installedPath,
 				dependencies,
+				currentVersion: mod.version || "",
 			});
 
 			await getAllInstalledMods();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -98,7 +98,7 @@
 <div class="app">
 	<h1>Welcome to Balatro Mod Manager</h1>
 	<BalatroPicker />
-	<div class="version-text">v0.1.8</div>
+	<div class="version-text">v0.1.9</div>
 </div>
 
 <style>

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -184,7 +184,7 @@
 		{onError}
 	/>
 
-	<div class="version-text">v0.1.8</div>
+	<div class="version-text">v0.1.9</div>
 </div>
 
 <style>

--- a/src/stores/modStore.ts
+++ b/src/stores/modStore.ts
@@ -16,6 +16,7 @@ export interface Mod {
 	repo: string;
 	downloadURL: string;
 	folderName: string;
+	version: string;
 	installed: boolean;
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `balatro-mod-manager` project, focusing on version updates, database enhancements, and new functionality for mod version management.

### Version Updates:
* Updated project version to `0.1.9` in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/bmm-lib/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src/components/viewblock/About.svelte`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R11) [[3]](diffhunk://#diff-cdf12443b7b969dec3b8dc8631ffd02b92fe35c47e5fefdb493d86e6238d891cL3-R3) [[4]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4) [[5]](diffhunk://#diff-b374c469d06df353ee29d9ac1f4789a57a5f5d92b8ce9c967eab949d90e8fcfdL73-R73)

### Database Enhancements:
* Added a `version` field to the `Mod` and `InstalledMod` structs in `src-tauri/bmm-lib/src/cache.rs` and `src-tauri/bmm-lib/src/database.rs`. [[1]](diffhunk://#diff-cb0c2a0f5eccd87c05828256c6732dedc0ee69317b868168c88b551f84235420R46) [[2]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R16)
* Updated SQL queries and methods to handle the new `version` field in `src-tauri/bmm-lib/src/database.rs`. [[1]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05L36-R39) [[2]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R48) [[3]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05L70-R73) [[4]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R210) [[5]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R222-R227)
* Added methods for getting and setting the last installed version of a mod in `src-tauri/bmm-lib/src/database.rs`.

### New Functionality:
* Implemented a new Tauri command `mod_update_available` to check if a mod update is available based on version comparison in `src-tauri/src/lib.rs`.
* Added logic to handle mod updates in the `add_installed_mod` function in `src-tauri/src/lib.rs`.
* Updated the `ModCard.svelte` component to include a refresh icon for mods with updates available in `src/components/viewblock/ModCard.svelte`.