### PR TITLE
Fix BalatroPicker UI

### DIFF
--- a/src/components/BalatroPicker.svelte
+++ b/src/components/BalatroPicker.svelte
@@ -5,7 +5,6 @@
 
 	import { goto } from "$app/navigation";
 
-
 	let selectedOption = "steam";
 	let showCustomInput = false;
 	let selectedPath = "";
@@ -181,6 +180,7 @@
 		justify-content: center;
 		align-items: center;
 		width: 100%;
+		overflow-x: hidden; /* Prevent horizontal scrolling */
 	}
 
 	.button-wrapper {
@@ -202,16 +202,17 @@
 		flex-direction: column;
 		align-items: center;
 		width: 400px;
+		max-width: 95vw; /* Ensure it doesn't overflow on smaller screens */
 		padding: 2.5rem;
 		border-radius: 25px;
 		background-color: var(--background-primary);
-		/* box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2); */
 		outline: 2px solid var(--color-medium);
 		color: var(--text-primary);
 		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 		height: auto;
 		min-height: 150px;
 		position: relative;
+		box-sizing: border-box; /* Include padding in width calculation */
 	}
 
 	.action-button {
@@ -286,8 +287,9 @@
 	}
 
 	.input-container {
-		width: 80%;
-		margin-top: 1rem;
+		width: 100%;
+		margin: 1rem 0; /* Change from 1rem to 1rem 0 to prevent horizontal overflow */
+		box-sizing: border-box; /* Include padding in width calculation */
 	}
 
 	h2 {
@@ -379,6 +381,7 @@
 		text-overflow: ellipsis;
 		-webkit-user-select: none;
 		user-select: none;
+		box-sizing: border-box; /* Include padding and border in width calculation */
 	}
 
 	input[type="text"]:hover {


### PR DESCRIPTION
This pull request includes several changes to improve the layout and responsiveness of the `BalatroPicker.svelte` component. The most important changes include adding CSS properties to prevent overflow and ensure proper width calculations.

Layout improvements:

* [`src/components/BalatroPicker.svelte`](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cR183): Added `overflow-x: hidden` to prevent horizontal scrolling.
* [`src/components/BalatroPicker.svelte`](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cR205-R215): Added `max-width: 95vw` to ensure the component doesn't overflow on smaller screens.
* [`src/components/BalatroPicker.svelte`](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cL289-R292): Changed the `.input-container` width to 100% and adjusted margins to prevent horizontal overflow.

Width calculation adjustments:

* [`src/components/BalatroPicker.svelte`](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cR205-R215): Added `box-sizing: border-box` to several elements to include padding and borders in width calculations. [[1]](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cR205-R215) [[2]](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cL289-R292) [[3]](diffhunk://#diff-a0cc67ff6df5884510d27f400cfaddd79b315ed66e7a5ea207d2206b3c4f5b4cR384)