### PR TITLE
Fix

### DIFF
--- a/src/components/viewblock/ModCard.svelte
+++ b/src/components/viewblock/ModCard.svelte
@@ -22,8 +22,13 @@
 	let { mod, oninstallclick, onuninstallclick, onmodclick }: Props = $props();
 
 	// Check if an update is available when component mounts
+	let updateChecked = false;
+
 	$effect(() => {
-		checkForUpdate(mod.title);
+		if (!updateChecked) {
+			updateChecked = true;
+			checkForUpdate(mod.title);
+		}
 	});
 
 	async function checkForUpdate(modName: string) {


### PR DESCRIPTION
This pull request includes an important change to the `ModCard.svelte` component to ensure that the update check is performed only once when the component mounts.

Key change:

* [`src/components/viewblock/ModCard.svelte`](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4R25-R31): Added a `updateChecked` flag to prevent multiple update checks by ensuring that the `checkForUpdate` function is called only once when the component mounts.