### PR TITLE
[linux support] docker fixes and speed enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,15 +11,15 @@ vite.config.ts.timestamp-*
 /scripts/build_for_release.sh
 /.hack/linux/bundles
 
-/src-tauri/target
-/src-tauri/gen/schemas
-/src-tauri/storage.db
+/src-tauri/**/target
+/src-tauri/**/gen/schemas
+/src-tauri/**/storage.db
 
 .git
 .github
 .vscode
-Dockerfile
-*.Dockerfile
+**/*/Dockerfile
+**/*/*.Dockerfile
 .dockerignore
 .gitignore
 .npmrc
@@ -29,6 +29,10 @@ README.md
 Taskfile.yml
 flake.nix
 flake.lock
+shell.nix
+default.nix
 /result
 /.hack/pnpm-lock.yaml
 /.hack/linux/bundle.sh
+/scripts/
+/version_updater/

--- a/.hack/linux/Dockerfile
+++ b/.hack/linux/Dockerfile
@@ -20,14 +20,19 @@ FROM base AS builder
 WORKDIR /app/src
 COPY . .
 RUN bun i
-RUN bun tauri build --target x86_64-unknown-linux-gnu --verbose
+RUN \
+    --mount=type=cache,target=/app/src/src-tauri/target/ \
+    --mount=type=cache,target=/app/src/src-tauri/bmm-lib/target/ \
+    --mount=type=cache,target=/root/.cargo/registry/cache/git/db \
+    --mount=type=cache,target=/root/.cargo/registry/cache/registry/ \
+  bun tauri build --target x86_64-unknown-linux-gnu --verbose && \
+  mkdir /app/bundles && cp \
+    src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb \
+    src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm \
+    src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage \
+    /app/bundles
 
 
 FROM ubuntu AS output
 
-WORKDIR /app/bundles
-COPY --from=builder \
-  /app/src/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb \
-  /app/src/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm \
-  /app/src/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage \
-  ./
+COPY --from=builder /app/bundles /app/bundles

--- a/.hack/linux/Dockerfile
+++ b/.hack/linux/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:noble@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe098
 
 FROM ubuntu AS base
 
-COPY .linux/install-deps.sh .
+COPY .hack/linux/install-deps.sh .
 RUN ./install-deps.sh && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
 

--- a/.hack/linux/bundle.sh
+++ b/.hack/linux/bundle.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -xe
 
-mkdir -p .linux/bundles
-output_dir="$PWD/.linux/bundles/$(date --utc +%Y%m%d_%H%M%SZ)"
+WORKDIR="$PWD/.hack/linux"
+OUTDIR="${WORKDIR}/bundles/$(date --utc +%Y%m%d_%H%M%SZ)"
+mkdir -p "${OUTDIR}"
 
 # Build image and tag it with a temporary name
-docker buildx build -f .linux/Dockerfile . --load -t balatro-mod-manager-temp
+docker buildx build -f "${WORKDIR}"/Dockerfile . --load -t balatro-mod-manager:temp
 
 # Use the tagged image name
-docker run --rm -v "$output_dir:/output" balatro-mod-manager-temp bash -c 'cp /app/bundles/* /output/'
+docker run --rm -v "${OUTDIR}:/output" balatro-mod-manager:temp bash -c 'cp /app/bundles/* /output/'

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ or with the Nix package manager:
           **Prerequisites**: Ensure you have Docker, Docker Compose, and Docker Buildx installed:
           ```
           # For Arch Linux
-          sudo pacman -S docker docker-compose docker-buildx
+          sudo pacman -S docker docker-buildx
 
           # For Ubuntu/Debian
-          sudo apt install docker.io docker-compose docker-buildx-plugin
+          sudo apt install docker.io docker-buildx-plugin
 
           # For Fedora/RHEL
-          sudo dnf install docker docker-compose docker-buildx-plugin
+          sudo dnf install docker docker-buildx-plugin
           ```
 
           Then build with:


### PR DESCRIPTION
adds onto #66 & #131:

- docker bundle: persist cargo caches across builds, prevents crate recompilation on every build
- docker bundle: fix outdated paths, use conventional tag and constant names
- .dockerignore: only keep actual BMM source code, so only code changes invalidate the cache
- readme: remove `compose` from docker prerequisites