### PR TITLE
164 implement automatic build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for changelog generation
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
@@ -54,13 +56,61 @@ jobs:
         # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
         run: bun install # change this to npm or pnpm depending on which one you use.
 
+      - name: Generate Release Notes
+        if: matrix.platform == 'ubuntu-22.04' # Only run once
+        id: generate_notes
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          
+          echo "## What's New" > RELEASE_NOTES.md
+          
+          if [ "$LATEST_TAG" != "none" ]; then
+            # Generate changelog from commits since the last tag
+            echo "### Changes since $LATEST_TAG" >> RELEASE_NOTES.md
+            git log $LATEST_TAG..HEAD --pretty=format:"- %s" --reverse | grep -v "Merge" >> RELEASE_NOTES.md
+          else
+            # No previous tags, list recent commits
+            echo "### Initial Release" >> RELEASE_NOTES.md
+            git log --pretty=format:"- %s" --reverse -n 10 | grep -v "Merge" >> RELEASE_NOTES.md
+          fi
+          
+          # Add the security warning template
+          cat >> RELEASE_NOTES.md << 'EOL'
+          
+          ## ⚠️ Important Security Note for Windows Users
+          Our .exe and .msi installers are unsigned at this time. This means:
+
+              Windows Defender/SmartScreen will show "Windows protected your PC"
+              Antivirus software might flag the files
+
+          ## Why?
+          We're a brand-new project and code signing certificates cost ~$400/year.
+
+          How to install safely:
+          1. Download the files from Assets below
+          2. On the warning screen: Click "More info" → "Run anyway"
+
+          ❓ FAQ
+          Q: Why is Windows blocking the installer?
+          A: We're unsigned – verify the code here first!
+          Q: How do I know this isn't malware?
+          A: Check the source code
+          EOL
+          
+          # Store release notes to be used by tauri-action
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          cat RELEASE_NOTES.md >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
-          releaseName: 'App v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
+          releaseName: 'Balatro Mod Manager v__VERSION__ (Alpha Build) Pre-release'
+          releaseBody: ${{ env.RELEASE_NOTES }}
           releaseDraft: true
-          prerelease: false
+          prerelease: true
           args: ${{ matrix.args }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for changelog generation
+          fetch-depth: 0
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      # Import macOS certificate (new step)
+      - name: Install Apple certificate
+        if: matrix.platform == 'macos-latest'
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - release
+      - 164-implement-automatic-build-workflow
 
 jobs:
   publish-tauri:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
-      - name: setup node
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
         with:
-          node-version: lts/*
-          cache: 'bun' # Set this to npm, yarn or pnpm.
+          bun-version: latest
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable # Set this to dtolnay/rust-toolchain@nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: 'macos-latest' # for Arm based macs (M1 and above).
-            args: '--target aarch64-apple-darwin'
-          - platform: 'macos-latest' # for Intel based macs.
-            args: '--target x86_64-apple-darwin'
+          - platform: 'macos-latest'
+            args: '--target universal-apple-darwin'
           - platform: 'ubuntu-22.04'
             args: ''
           - platform: 'windows-latest'
@@ -28,13 +26,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for changelog generation
+          fetch-depth: 0
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Setup macOS Signing
+        if: matrix.platform == 'macos-latest'
+        run: |
+          # Import certificate
+          echo ${{ secrets.APPLE_CERTIFICATE }} | base64 --decode > certificate.p12
+          security create-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" build.keychain
+          security import certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" build.keychain
+          rm certificate.p12
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -42,9 +52,8 @@ jobs:
           bun-version: latest
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable # Set this to dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
-          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
@@ -53,13 +62,13 @@ jobs:
           workspaces: './src-tauri -> target'
 
       - name: install frontend dependencies
-        # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
-        run: bun install # change this to npm or pnpm depending on which one you use.
+        run: bun install
 
       - name: Generate Release Notes
-        if: matrix.platform == 'ubuntu-22.04' # Only run once
+        if: matrix.platform == 'ubuntu-22.04'
         id: generate_notes
         run: |
+          # [your existing release notes generation code]
           # Get the latest tag
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
           
@@ -106,8 +115,12 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          MACOSX_DEPLOYMENT_TARGET: 11.0
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          tagName: app-v__VERSION__
           releaseName: 'Balatro Mod Manager v__VERSION__ (Alpha Build) Pre-release'
           releaseBody: ${{ env.RELEASE_NOTES }}
           releaseDraft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,31 +34,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
-      - name: Setup macOS Signing
-        if: matrix.platform == 'macos-latest'
-        run: |
-          # Create a temporary file for the certificate
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          
-          # Import certificate from secrets
-          echo -n "${{ secrets.APPLE_CERTIFICATE }}" | base64 --decode --output $CERTIFICATE_PATH
-          
-          # Create temporary keychain
-          security create-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" $KEYCHAIN_PATH
-          
-          # Add certificate to keychain
-          security import $CERTIFICATE_PATH -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-          
-          # Allow codesigning from keychain
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" $KEYCHAIN_PATH
-          
-          # Clean up temp file
-          rm $CERTIFICATE_PATH
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -80,50 +55,7 @@ jobs:
       - name: Generate Release Notes
         if: matrix.platform == 'ubuntu-22.04'
         id: generate_notes
-        run: |
-          # [your existing release notes generation code]
-          # Get the latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
-          
-          echo "## What's New" > RELEASE_NOTES.md
-          
-          if [ "$LATEST_TAG" != "none" ]; then
-            # Generate changelog from commits since the last tag
-            echo "### Changes since $LATEST_TAG" >> RELEASE_NOTES.md
-            git log $LATEST_TAG..HEAD --pretty=format:"- %s" --reverse | grep -v "Merge" >> RELEASE_NOTES.md
-          else
-            # No previous tags, list recent commits
-            echo "### Initial Release" >> RELEASE_NOTES.md
-            git log --pretty=format:"- %s" --reverse -n 10 | grep -v "Merge" >> RELEASE_NOTES.md
-          fi
-          
-          # Add the security warning template
-          cat >> RELEASE_NOTES.md << 'EOL'
-          
-          ## ⚠️ Important Security Note for Windows Users
-          Our .exe and .msi installers are unsigned at this time. This means:
-
-              Windows Defender/SmartScreen will show "Windows protected your PC"
-              Antivirus software might flag the files
-
-          ## Why?
-          We're a brand-new project and code signing certificates cost ~$400/year.
-
-          How to install safely:
-          1. Download the files from Assets below
-          2. On the warning screen: Click "More info" → "Run anyway"
-
-          ❓ FAQ
-          Q: Why is Windows blocking the installer?
-          A: We're unsigned – verify the code here first!
-          Q: How do I know this isn't malware?
-          A: Check the source code
-          EOL
-          
-          # Store release notes to be used by tauri-action
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          cat RELEASE_NOTES.md >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+        # [your existing release notes generation code here]
 
       - uses: tauri-apps/tauri-action@v0
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: 'publish'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-22.04'
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'bun' # Set this to npm, yarn or pnpm.
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable # Set this to dtolnay/rust-toolchain@nightly
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: install frontend dependencies
+        # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
+        run: bun install # change this to npm or pnpm depending on which one you use.
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'App v__VERSION__'
+          releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,29 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
-      # Import macOS certificate (new step)
-      - name: Install Apple certificate
+      # macOS certificate setup (from Tauri docs)
+      - name: Import Apple Developer Certificate
         if: matrix.platform == 'macos-latest'
-        uses: apple-actions/import-codesign-certs@v2
-        with:
-          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
-          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          security find-identity -v -p codesigning build.keychain
+
+      - name: Verify Certificate
+        if: matrix.platform == 'macos-latest'
+        run: |
+          CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
+          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+          echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
+          echo "Certificate imported. ID: $CERT_ID"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -110,7 +126,7 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'macos-latest' && env.CERT_ID || '' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           MACOSX_DEPLOYMENT_TARGET: 11.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - release
-      - 164-implement-automatic-build-workflow
 
 jobs:
   publish-tauri:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Fetch all history for changelog generation
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'
@@ -55,7 +55,49 @@ jobs:
       - name: Generate Release Notes
         if: matrix.platform == 'ubuntu-22.04'
         id: generate_notes
-        # [your existing release notes generation code here]
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          
+          echo "## What's New" > RELEASE_NOTES.md
+          
+          if [ "$LATEST_TAG" != "none" ]; then
+            # Generate changelog from commits since the last tag
+            echo "### Changes since $LATEST_TAG" >> RELEASE_NOTES.md
+            git log $LATEST_TAG..HEAD --pretty=format:"- %s" --reverse | grep -v "Merge" >> RELEASE_NOTES.md
+          else
+            # No previous tags, list recent commits
+            echo "### Initial Release" >> RELEASE_NOTES.md
+            git log --pretty=format:"- %s" --reverse -n 10 | grep -v "Merge" >> RELEASE_NOTES.md
+          fi
+          
+          # Add the security warning template
+          cat >> RELEASE_NOTES.md << 'EOL'
+          
+          ## ⚠️ Important Security Note for Windows Users
+          Our .exe and .msi installers are unsigned at this time. This means:
+
+              Windows Defender/SmartScreen will show "Windows protected your PC"
+              Antivirus software might flag the files
+
+          ## Why?
+          We're a brand-new project and code signing certificates cost ~$400/year.
+
+          How to install safely:
+          1. Download the files from Assets below
+          2. On the warning screen: Click "More info" → "Run anyway"
+
+          ❓ FAQ
+          Q: Why is Windows blocking the installer?
+          A: We're unsigned – verify the code here first!
+          Q: How do I know this isn't malware?
+          A: Check the source code
+          EOL
+          
+          # Store release notes to be used by tauri-action
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          cat RELEASE_NOTES.md >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - uses: tauri-apps/tauri-action@v0
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,27 @@ jobs:
       - name: Setup macOS Signing
         if: matrix.platform == 'macos-latest'
         run: |
-          # Import certificate
-          echo ${{ secrets.APPLE_CERTIFICATE }} | base64 --decode > certificate.p12
-          security create-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" build.keychain
-          security import certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" build.keychain
-          rm certificate.p12
+          # Create a temporary file for the certificate
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          
+          # Import certificate from secrets
+          echo -n "${{ secrets.APPLE_CERTIFICATE }}" | base64 --decode --output $CERTIFICATE_PATH
+          
+          # Create temporary keychain
+          security create-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" $KEYCHAIN_PATH
+          
+          # Add certificate to keychain
+          security import $CERTIFICATE_PATH -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          
+          # Allow codesigning from keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" $KEYCHAIN_PATH
+          
+          # Clean up temp file
+          rm $CERTIFICATE_PATH
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
-      # macOS certificate setup (from Tauri docs)
+      # macOS certificate setup
       - name: Import Apple Developer Certificate
         if: matrix.platform == 'macos-latest'
         env:
@@ -129,6 +129,7 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'macos-latest' && env.CERT_ID || '' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MACOSX_DEPLOYMENT_TARGET: 11.0
         with:
           tagName: app-v__VERSION__

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MACOSX_DEPLOYMENT_TARGET: 11.0
         with:
-          tagName: app-v__VERSION__
+          tagName: v__VERSION__
           releaseName: 'Balatro Mod Manager v__VERSION__ (Alpha Build) Pre-release'
           releaseBody: ${{ env.RELEASE_NOTES }}
           releaseDraft: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing the project. The workflow is designed to handle different platforms and includes steps for setting up dependencies, managing certificates, and generating release notes.

Key changes:

* **New Workflow Setup:**
  * Added a new workflow named `publish` that triggers on `workflow_dispatch` and `push` events to the `release` branch.

* **Job Configuration:**
  * Configured the `publish-tauri` job to run on macOS, Ubuntu, and Windows platforms, with appropriate setup steps for each platform.

* **Dependency Installation:**
  * Included steps to install necessary dependencies for Ubuntu and macOS platforms, including Rust and frontend dependencies.

* **Certificate Management:**
  * Added steps for importing and verifying the Apple Developer Certificate on macOS to enable code signing.

* **Release Notes Generation:**
  * Implemented a script to generate release notes based on git commit history and included a security warning for Windows users.