### PR TITLE
Add creds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,8 @@ jobs:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'macos-latest' && env.CERT_ID || '' }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MACOSX_DEPLOYMENT_TARGET: 11.0
           TAURI_SKIP_APPLE_NOTARIZATION: true # Skip notarization during build


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build.yml` file to enhance the CI/CD pipeline for macOS builds. The most important changes involve the addition of new environment variables for Apple authentication.

Enhancements to CI/CD pipeline:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R99-R100): Added `APPLE_ID` and `APPLE_PASSWORD` environment variables to support Apple authentication during the build process.