### PR TITLE
ci: build on every push to `66-linux-support`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - release
+      - 66-linux-support
 
 jobs:
   build-tauri:


### PR DESCRIPTION
to test the binaries built by the tauri action, and provide a more sane source to link others to for appimage downloads