### PR TITLE
Revert "ci: build on every push to `66-linux-support`"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - release
-      - 66-linux-support
 
 jobs:
   build-tauri:


### PR DESCRIPTION
Reverts skyline69/balatro-mod-manager#176