### PR TITLE
Check Tauri CLI version in install script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,6 +65,32 @@ foreach ($dep in $deps) {
     }
 }
 
+# Check cargo-tauri version
+Write-Host "Checking Tauri CLI version..." -ForegroundColor $YELLOW
+try {
+    $tauriVersionOutput = (cargo tauri --version) -join ""
+    if ($tauriVersionOutput -match '(\d+\.\d+\.\d+)') {
+        $TAURI_VERSION = $matches[1]
+        $REQUIRED_VERSION = "2.3.1"
+        
+        # Convert versions to System.Version for proper comparison
+        $currentVersion = [System.Version]$TAURI_VERSION
+        $requiredVersion = [System.Version]$REQUIRED_VERSION
+        
+        if ($currentVersion -lt $requiredVersion) {
+            Write-Host "Error: cargo-tauri version $TAURI_VERSION is too old. Please update to at least version $REQUIRED_VERSION" -ForegroundColor $RED
+            exit 1
+        }
+        Write-Host "cargo-tauri version $TAURI_VERSION ✓" -ForegroundColor $GREEN
+    } else {
+        Write-Host "Error: Unable to determine cargo-tauri version" -ForegroundColor $RED
+        exit 1
+    }
+} catch {
+    Write-Host "Error checking cargo-tauri version: $_" -ForegroundColor $RED
+    exit 1
+}
+
 # Create temp directory
 $BUILD_DIR = Join-Path $env:TEMP "balatro-mod-manager-$(Get-Date -Format 'yyyyMMddHHmmss')"
 Write-Host "Creating temporary build directory: ${BUILD_DIR}" -ForegroundColor $YELLOW

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,7 +56,16 @@ if ! command -v cargo-tauri &> /dev/null; then
     exit 1
 fi
 
+# Check cargo-tauri version
+echo -e "${YELLOW}Checking Tauri CLI version...${NC}"
+TAURI_VERSION=$(cargo tauri --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+REQUIRED_VERSION="2.3.1"
 
+if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$TAURI_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+    echo -e "${RED}Error: cargo-tauri version $TAURI_VERSION is too old. Please update to at least version $REQUIRED_VERSION${NC}"
+    exit 1
+fi
+echo -e "${GREEN}cargo-tauri version $TAURI_VERSION ✓${NC}"
 
 # Create a temporary directory
 BUILD_DIR=$(mktemp -d)


### PR DESCRIPTION
This pull request introduces checks for the `cargo-tauri` version in both PowerShell (`install.ps1`) and shell script (`install.sh`) installation scripts. These changes ensure that the installed version of `cargo-tauri` meets the required minimum version of 2.3.1.

Version checks for `cargo-tauri`:

* [`scripts/install.ps1`](diffhunk://#diff-49e87bd475b9a24c9b32cbaa247e494097aa436fff27877e2b7777f2c5ac829bR68-R93): Added a check to verify that the `cargo-tauri` version is at least 2.3.1, and prompt the user to update if it is not.
* [`scripts/install.sh`](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR59-R68): Added a check to verify that the `cargo-tauri` version is at least 2.3.1, and prompt the user to update if it is not.