### PR TITLE
Purify HTML tags in descriptions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,22 +12,22 @@
         "@types/flexsearch": "^0.7.42",
         "@types/lodash": "4.17.16",
         "axios": "^1.8.4",
-        "flexsearch": "^0.8.149",
+        "flexsearch": "^0.8.154",
         "lodash": "^4.17.21",
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.8",
-        "@sveltejs/kit": "^2.20.3",
+        "@sveltejs/kit": "^2.20.5",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tauri-apps/cli": "^2.4.1",
         "lucide-svelte": "^0.483.0",
-        "marked": "^15.0.7",
-        "svelte": "^5.25.6",
-        "svelte-check": "^4.1.5",
+        "marked": "^15.0.8",
+        "svelte": "^5.26.3",
+        "svelte-check": "^4.1.6",
         "svelte-confetti": "^2.3.1",
         "tslib": "^2.8.1",
-        "typescript": "^5.8.2",
-        "vite": "^6.2.5",
+        "typescript": "^5.8.3",
+        "vite": "^6.2.6",
       },
     },
   },
@@ -302,7 +302,7 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "svelte": ["svelte@5.26.2", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^1.4.6", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-e2TEcGK2YKVwDWYy5OsptVclYgDvfY1E/8IzPiOq63uG/GDo/j5VUYTC9EinQNraoZalbMWN+5f5TYC1QlAqOw=="],
+    "svelte": ["svelte@5.26.3", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^1.4.6", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-SgDfx70CmW8Rev9XRu5sN/3Paa/mSh3DGxDDEgtecdjbhLrmgK18McanP+gNE8HYGm8tXiXZN3Fn31NcqBML+Q=="],
 
     "svelte-check": ["svelte-check@4.1.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-P7w/6tdSfk3zEVvfsgrp3h3DFC75jCdZjTQvgGJtjPORs1n7/v2VMPIoty3PWv7jnfEm3x0G/p9wH4pecTb0Wg=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@tauri-apps/cli": "^2.4.1",
 		"lucide-svelte": "^0.483.0",
 		"marked": "^15.0.8",
-		"svelte": "^5.26.2",
+		"svelte": "^5.26.3",
 		"svelte-check": "^4.1.6",
 		"svelte-confetti": "^2.3.1",
 		"tslib": "^2.8.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -839,7 +839,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1390,7 +1390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2720,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4148,7 +4148,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4161,7 +4161,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5200,7 +5200,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5342,9 +5342,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6013,7 +6013,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,33 +1,31 @@
 export function stripMarkdown(text: string): string {
+	if (!text) return ""; // Handle null or undefined input
+
 	return (
 		text
-			// Remove headers (#)
-			.replace(/#{1,6}\s/g, "")
-			// Remove bold/italic
-			.replace(/[*_]{1,3}(.*?)[*_]{1,3}/g, "$1")
-			// Remove links
-			.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
-			// Remove images
-			.replace(/!\[([^\]]+)\]\([^\)]+\)/g, "$1")
-			// Remove blockquotes
-			.replace(/^\s*>\s/gm, "")
-			// Remove code blocks
-			.replace(/```[\s\S]*?```/g, "")
-			// Remove inline code
-			.replace(/`([^`]+)`/g, "$1")
-			// Remove horizontal rules
-			.replace(/^\s*[-*_]{3,}\s*$/gm, "")
-			// Remove lists
-			.replace(/^[\s*-]+(.*)/gm, "$1")
-			// Clean up extra whitespace
-			.replace(/\n\s*\n/g, "\n")
+			// --- Add HTML tag removal FIRST ---
+			.replace(/<[^>]*>/g, "") // Remove HTML tags like <h1>, <i>, etc.
+
+			// --- Existing replacements ---
+			.replace(/#{1,6}\s/g, "") // Remove headers (#)
+			.replace(/[*_]{1,3}(.*?)[*_]{1,3}/g, "$1") // Remove bold/italic (*_)
+			.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1") // Remove links ([text](url))
+			.replace(/!\[([^\]]+)\]\([^\)]+\)/g, "$1") // Remove images (![alt](url))
+			.replace(/^\s*>\s/gm, "") // Remove blockquotes (>)
+			.replace(/```[\s\S]*?```/g, "") // Remove code blocks (```)
+			.replace(/`([^`]+)`/g, "$1") // Remove inline code (`)
+			.replace(/^\s*[-*_]{3,}\s*$/gm, "") // Remove horizontal rules (--- *** ___)
+			.replace(/^[\s*-]+(.*)/gm, "$1") // Remove list markers (might be too aggressive sometimes)
+
+			// --- Cleanup ---
+			.replace(/\n\s*\n/g, "\n") // Consolidate multiple newlines
+			.replace(/\s+/g, ' ')      // Replace consecutive whitespace (including newlines from tag removal) with a single space
 			.trim()
 	);
 }
 
 export function truncateText(text: string, maxLength: number = 65): string {
+	if (!text) return ""; // Handle null or undefined input
 	if (text.length <= maxLength) return text;
 	return text.slice(0, maxLength).trim() + "...";
 }
-
-


### PR DESCRIPTION
This pull request includes updates to the `package.json` file and enhancements to the `stripMarkdown` and `truncateText` functions in `src/utils/helpers.ts`.

### Dependency updates:
* Updated the `svelte` dependency version from `^5.26.2` to `^5.26.3` in `package.json` to ensure compatibility with the latest features and fixes.

### Code enhancements:
* Enhanced the `stripMarkdown` function to handle null or undefined input and added HTML tag removal before existing markdown replacements. It also now consolidates multiple newlines and replaces consecutive whitespace with a single space.
* Enhanced the `truncateText` function to handle null or undefined input, ensuring robustness in edge cases.