### PR TITLE
Fix toggle button issue

### DIFF
--- a/src/components/viewblock/LocalModCard.svelte
+++ b/src/components/viewblock/LocalModCard.svelte
@@ -56,10 +56,6 @@
 	async function toggleModEnabled(e: Event) {
 		e.stopPropagation();
 		try {
-			console.log(
-				`Toggling local mod ${mod.name} from ${isEnabled ? "enabled" : "disabled"} to ${!isEnabled ? "enabled" : "disabled"}`,
-			);
-
 			const currentState = $modEnabledStore[mod.name] ?? isEnabled;
 			const newState = !currentState;
 
@@ -68,10 +64,6 @@
 				modPath: mod.path,
 				enabled: newState,
 			});
-
-			console.log(
-				`Backend toggle completed for ${mod.name}, updating store...`,
-			);
 
 			// Update both the store and local variable
 			modEnabledStore.update((enabledMods) => ({
@@ -82,9 +74,7 @@
 
 			// Call the parent callback to update the filtered lists
 			if (onToggleEnabled) {
-				console.log(`Calling parent callback for ${mod.name}`);
 				await onToggleEnabled();
-				console.log(`Parent callback completed for ${mod.name}`);
 			}
 		} catch (error) {
 			console.error(
@@ -373,6 +363,22 @@
 				on:click={openModDirectory}
 			>
 				<Folder size={18} />
+			</button>
+			<!-- Added toggle button here -->
+			<button
+				class="toggle-button"
+				class:enabled={$modEnabledStore[mod.name] ?? isEnabled}
+				class:disabled={!($modEnabledStore[mod.name] ?? isEnabled)}
+				title={($modEnabledStore[mod.name] ?? isEnabled)
+					? "Disable Mod"
+					: "Enable Mod"}
+				on:click={toggleModEnabled}
+			>
+				{#if $modEnabledStore[mod.name] ?? isEnabled}
+					ON
+				{:else}
+					OFF
+				{/if}
 			</button>
 			<button
 				class="delete-button"


### PR DESCRIPTION
This pull request refactors the `LocalModCard.svelte` component by removing unnecessary `console.log` statements and adding a new toggle button for enabling or disabling mods. These changes improve both the user interface and the maintainability of the code.

### Logging Cleanup:
* Removed multiple `console.log` statements from the `toggleModEnabled` function to reduce noise in the console and improve code cleanliness. [[1]](diffhunk://#diff-705ee6b68e8ee77e7d3b3a173889b3cac5e464ac86de70c3394648306aa7515cL59-L62) [[2]](diffhunk://#diff-705ee6b68e8ee77e7d3b3a173889b3cac5e464ac86de70c3394648306aa7515cL72-L75) [[3]](diffhunk://#diff-705ee6b68e8ee77e7d3b3a173889b3cac5e464ac86de70c3394648306aa7515cL85-L87)

### UI Enhancement:
* Added a new toggle button to the UI for enabling or disabling mods. The button dynamically updates its state and title based on the current mod status (`enabled` or `disabled`).