### PR TITLE
Add Security Popup at start

### DIFF
--- a/src-tauri/bmm-lib/src/discord_rpc.rs
+++ b/src-tauri/bmm-lib/src/discord_rpc.rs
@@ -91,7 +91,7 @@ impl DiscordRpcManager {
 
                 // Update activity for existing client
                 if let Some(client) = client_guard.as_mut() {
-                    log::debug!("Updating Discord activity");
+                    // log::debug!("Updating Discord activity");
                     let activity = activity::Activity::new()
                         .state("Managing Balatro mods")
                         .details("Using Balatro Mod Manager")
@@ -110,7 +110,7 @@ impl DiscordRpcManager {
                         }
                         *client_guard = None;
                     } else {
-                        log::debug!("Activity updated successfully");
+                        // log::debug!("Activity updated successfully");
                     }
                 }
             }
@@ -156,7 +156,7 @@ impl DiscordRpcManager {
         };
 
         if let Some(client) = client_guard.as_mut() {
-            log::info!("Updating Discord activity: {} - {}", state, details);
+            // log::info!("Updating Discord activity: {} - {}", state, details);
             let activity = activity::Activity::new()
                 .state(state)
                 .details(details)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1727,6 +1727,27 @@ async fn check_custom_balatro(
     Ok(is_valid)
 }
 
+#[tauri::command]
+async fn is_security_warning_acknowledged(state: tauri::State<'_, AppState>) -> Result<bool, String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    map_error(db.is_security_warning_acknowledged())
+}
+
+#[tauri::command]
+async fn set_security_warning_acknowledged(
+    state: tauri::State<'_, AppState>,
+    acknowledged: bool,
+) -> Result<(), String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    map_error(db.set_security_warning_acknowledged(acknowledged))
+}
+
+#[tauri::command]
+fn exit_application(app_handle: tauri::AppHandle) {
+    app_handle.exit(0);
+}
+
+
 // #[tauri::command]
 // async fn get_installed_mods() -> Vec<String> {
 //     bmm_lib::finder::get_installed_mods()
@@ -1842,6 +1863,9 @@ pub fn run() {
             toggle_mod_enabled,
             is_mod_enabled_by_path,
             toggle_mod_enabled_by_path,
+            set_security_warning_acknowledged,
+            is_security_warning_acknowledged,
+            exit_application
         ])
         .run(tauri::generate_context!());
 

--- a/src/components/SecurityPopup.svelte
+++ b/src/components/SecurityPopup.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { fade, scale } from "svelte/transition";
+	import { invoke } from "@tauri-apps/api/core";
+
+	export let visible: boolean = false;
+	export let onAcknowledge: () => void;
+	export let onCancel: () => void;
+
+	let isLoading: boolean = false;
+	let errorMessage: string | null = null;
+
+	async function handleAcknowledge() {
+		try {
+			isLoading = true;
+			errorMessage = null;
+
+			// Always store acknowledgment when user clicks "I Understand"
+			await invoke("set_security_warning_acknowledged", {
+				acknowledged: true,
+			});
+
+			// Then call the parent component's callback
+			onAcknowledge();
+		} catch (error) {
+			console.error("Failed to save security acknowledgment:", error);
+			errorMessage = "Failed to save your preference. Please try again.";
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	function handleQuit() {
+		// Close the application
+		invoke("exit_application");
+		onCancel();
+	}
+</script>
+
+{#if visible}
+	<div class="modal-background" transition:fade={{ duration: 100 }}>
+		<div
+			class="modal"
+			transition:scale={{ duration: 200, start: 0.95, opacity: 1 }}
+		>
+			<h2>Security Notice</h2>
+			<p>
+				Mods are created and maintained by third-party developers. While
+				the index is curated, we cannot guarantee their safety. Please
+				install only if you trust the source.
+			</p>
+			{#if errorMessage}
+				<p class="error-message">{errorMessage}</p>
+			{/if}
+			<div class="buttons">
+				<button
+					class="cancel-button"
+					on:click={handleQuit}
+					disabled={isLoading}
+				>
+					Quit
+				</button>
+				<button
+					class="confirm-button"
+					on:click={handleAcknowledge}
+					disabled={isLoading}
+				>
+					{#if isLoading}
+						Saving...
+					{:else}
+						I Understand
+					{/if}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-background {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 999;
+	}
+	.modal {
+		background: #2d2d2d;
+		outline: 2px solid #f87171;
+		padding: 2rem;
+		border-radius: 8px;
+		box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
+		max-width: 500px;
+		width: 90%;
+		text-align: center;
+	}
+	h2 {
+		color: #f87171;
+		margin-bottom: 1rem;
+		font-family: "M6X11", sans-serif;
+	}
+	p {
+		color: #f4eee0;
+		font-size: 1.2rem;
+		margin-bottom: 1.5rem;
+		font-family: "M6X11", sans-serif;
+	}
+	.error-message {
+		color: #f87171;
+		font-size: 0.9rem;
+		margin-bottom: 1rem;
+		font-family: "M6X11", sans-serif;
+	}
+	.buttons {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+	}
+	button {
+		padding: 0.8rem 1.5rem;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 1rem;
+		transition: all 0.2s ease;
+		font-family: "M6X11", sans-serif;
+	}
+	button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+	.cancel-button {
+		background: #f87171;
+		outline: #f0a7a7 solid 2px;
+		color: #fff;
+	}
+	.confirm-button {
+		background: #56a786;
+		outline: #74cca8 solid 2px;
+		color: #fff;
+	}
+	button:hover:not(:disabled) {
+		opacity: 0.9;
+		scale: 1.05;
+		transition: all 0.2s ease;
+	}
+</style>


### PR DESCRIPTION
This pull request introduces a new feature to display a security acknowledgment popup and includes associated database and UI changes. It also removes some debug logging in the Discord RPC manager. The most important changes are grouped into database updates, UI enhancements, and logging adjustments.

### Database Updates:
* Updated `CURRENT_DB_VERSION` to "1.1" to reflect schema changes.
* Added methods and migration logic to handle a new `security_warning_acknowledged` setting in the database. [[1]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R244-R254) [[2]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R332-R337) [[3]](diffhunk://#diff-04490ea6ea487c3878a6b8f6a045999c84da559b1ccf9833e739ee9c25510f05R581-R603)
* Exposed Tauri commands `is_security_warning_acknowledged` and `set_security_warning_acknowledged` for external interaction. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR1730-R1750) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR1866-R1868)

### UI Enhancements:
* Added a new `SecurityPopup.svelte` component to display the security acknowledgment message and handle user interactions.
* Integrated `SecurityPopup` into the main application flow, including logic to check acknowledgment status on app launch and before certain actions. [[1]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR9) [[2]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL23-R24) [[3]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR37-R98) [[4]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR112) [[5]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL111-L126) [[6]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eL135-R195) [[7]](diffhunk://#diff-9f557cdb9444a8400862023c52b460e0a96efd78c5d6bff45e20f60edc39492eR267-R273)

### Logging Adjustments:
* Commented out debug and info logging statements in `DiscordRpcManager` to reduce log verbosity. [[1]](diffhunk://#diff-4602e0b134a8dd12ecc20f177523b2bf32e80d43070c90de0bc6bcd67caf8acaL94-R94) [[2]](diffhunk://#diff-4602e0b134a8dd12ecc20f177523b2bf32e80d43070c90de0bc6bcd67caf8acaL113-R113) [[3]](diffhunk://#diff-4602e0b134a8dd12ecc20f177523b2bf32e80d43070c90de0bc6bcd67caf8acaL159-R159)