### PR TITLE
Fix reloading mods when changing tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/`: SvelteKit UI (components, routes, stores, utils).
+- `src-tauri/`: Tauri app and Rust backend (`lib.rs`, commands, config).
+- `src-tauri/bmm-lib/`: Core Rust library used by the app.
+- `static/` and `images/`: Static assets bundled at build.
+- `scripts/`, `.github/`, `build/`: Helper scripts, CI, and build output.
+- `tests/`: Shared Rust test helpers; crate-specific tests live next to code.
+
+## Build, Test, and Development Commands
+- Dev (desktop): `task debug` or `bun run tauri dev` — launches the Tauri app.
+- Dev (web only): `bun run dev` — Vite dev server for UI.
+- Build (desktop): `task release` or `bun run tauri build` — production bundle.
+- Preview (web): `bun run preview` — serves built UI.
+- Type check: `bun run check` — Svelte/TS checks.
+- Rust tests: `cargo test` in `src-tauri/` and `src-tauri/bmm-lib/`.
+- Clean: `task clean` — removes build artifacts.
+
+## Coding Style & Naming Conventions
+- Svelte/TS: 2-space indent; components `PascalCase.svelte`; stores/utils `camelCase.ts`.
+- Routing: follow SvelteKit `+page.svelte`, `+layout.svelte` patterns.
+- Rust: `snake_case` for modules/functions, `CamelCase` for types; prefer `Result` over panics.
+- Format: run `cargo fmt` (Rust); use editor formatting for Svelte/TS; keep imports ordered.
+
+## Testing Guidelines
+- Rust unit tests live beside code (`#[cfg(test)]`); integration tests per crate; use `rstest` when helpful.
+- Name tests with descriptive `snake_case`; focus on core logic and file/IO boundaries.
+- Frontend: no formal unit tests; use `bun run check` and manual flows for regressions.
+- Run: `cargo test -q` in `src-tauri/` and `src-tauri/bmm-lib/` before PRs.
+
+## Commit & Pull Request Guidelines
+- Commits: imperative mood; small, focused. Conventional prefixes allowed (e.g., `feat:`, `fix:`, `chore:`).
+- PRs: clear description, linked issues, test steps, platforms tested (Windows/macOS), and screenshots/GIFs for UI changes.
+- Keep changes scoped; update `README.md` or in-app help if behavior changes.
+
+## Security & Configuration Tips
+- Do not commit secrets or signing identities. macOS signing is configured in `Taskfile.yml` for local use only.
+- Ensure Rust toolchain, Bun, and Tauri prerequisites are installed for your OS.

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -230,14 +230,17 @@
 		class:modal-open={!!$currentModView && currentSection == "mods"}
 		bind:this={contentElement}
 	>
-		{#if currentSection === "mods"}
+		<!-- Keep Mods mounted to preserve state and avoid re-fetching
+		     Use display: contents when visible to avoid layout shifts -->
+		<div class="section" style:display={currentSection !== "mods" ? 'none' : 'contents'}>
 			<Mods
 				mod={null}
 				{handleDependencyCheck}
 				on:request_uninstall={handleRequestUninstall}
 			/>
-		{/if}
+		</div>
 
+		<!-- Settings and About can remain conditional to save resources -->
 		{#if currentSection === "settings"}
 			<Settings />
 		{/if}


### PR DESCRIPTION
This pull request introduces documentation improvements and a frontend update to enhance the developer experience and UI responsiveness. The main changes are the addition of a comprehensive repository guidelines document and a UI tweak to optimize how the Mods section is rendered in the main page.

**Documentation improvements:**

* Added a new `AGENTS.md` file detailing project structure, build/test commands, coding conventions, testing guidelines, commit/PR practices, and security tips. This serves as a central reference for contributors and helps standardize workflows.

**Frontend/UI enhancements:**

* Updated `src/routes/main/+page.svelte` so the Mods section is always mounted (using a `<div>` with conditional `display: contents`), preserving its state and preventing unnecessary re-fetching or layout shifts when switching sections. Settings and About sections remain conditionally rendered for efficiency.