### PR TITLE
252 fix enable lovely console toggle in settings

### DIFF
--- a/src-tauri/src/commands/install.rs
+++ b/src-tauri/src/commands/install.rs
@@ -89,6 +89,12 @@ pub async fn launch_balatro(state: tauri::State<'_, AppState>) -> Result<(), Str
     // Respect the "Enable Lovely Console" setting on Windows by hiding the console
     // when disabled. If enabled, let the process manage its own console normally.
     if !lovely_console_enabled {
+        // Ask Lovely to suppress its console and also prevent a console window
+        // from being created for the process.
+        cmd.arg("--disable-console");
+        cmd.env("LOVELY_DISABLE_CONSOLE", "1");
+        cmd.env("LOVELY_NO_CONSOLE", "1");
+        cmd.env("LOVELY_CONSOLE", "0");
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 


### PR DESCRIPTION
This pull request updates the Windows launch behavior for Balatro to respect the "Enable Lovely Console" setting, improving how the application manages its console window based on user preferences.

Windows launch behavior improvements:

* The `launch_balatro` command now checks the "Enable Lovely Console" setting and, if disabled, adds arguments and environment variables to suppress the console and uses `CREATE_NO_WINDOW` to prevent a console window from appearing. (`src-tauri/src/commands/install.rs`)