### PR TITLE
feat(ui): card size slider + scalable mod cards

### DIFF
--- a/src/components/viewblock/LocalModCard.svelte
+++ b/src/components/viewblock/LocalModCard.svelte
@@ -281,9 +281,10 @@
 	if (mod.catalog_match && mod.catalog_match.version && mod.version) {
 		hasNewerVersion = mod.catalog_match.version !== mod.version;
 	}
+    import { cardScale } from "../../stores/ui";
 </script>
 
-<div class="mod-card" style="--bg-color: {bgColor}; --bg-color-2: {bgColor2};">
+<div class="mod-card" class:compact={$cardScale <= 0.85} style="--bg-color: {bgColor}; --bg-color-2: {bgColor2};">
 	<!-- Dark overlay to improve readability -->
 	<div class="overlay"></div>
 
@@ -408,9 +409,9 @@
 		border-radius: 8px;
 		overflow: hidden;
 		border: 2px solid #f4eee0;
-		width: 300px;
-		max-width: 300px;
-		height: 330px;
+		width: calc(300px * var(--card-scale, 1));
+		max-width: calc(300px * var(--card-scale, 1));
+		height: calc(330px * var(--card-scale, 1));
 		margin: 0 auto;
 		padding: 1rem;
 		box-sizing: border-box;
@@ -478,9 +479,21 @@
 
 	h3 {
 		color: #fdcf51;
-		font-size: 1.5rem;
+		font-size: calc(1.5rem * var(--card-scale, 1));
 		margin-bottom: 0.5rem;
 		text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+	}
+
+	/* Compact cards: clamp title to 1 line only when compact */
+	.mod-card.compact h3 {
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 1;
+		line-clamp: 1;
+		overflow: hidden;
+		word-break: break-word;
+		overflow-wrap: anywhere;
+		text-overflow: ellipsis;
 	}
 
 	.description {
@@ -494,6 +507,14 @@
 		line-clamp: 3;
 		-webkit-box-orient: vertical;
 		padding: 0 0.1rem;
+		word-break: break-word;
+		overflow-wrap: anywhere;
+		text-overflow: ellipsis;
+	}
+
+	.mod-card.compact .description {
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
 	}
 
 	.mod-meta {
@@ -530,15 +551,15 @@
 		align-items: center;
 		justify-content: center;
 		gap: 0.5rem;
-		padding: 0.75rem;
+		padding: calc(0.75rem * var(--card-scale, 1));
 		color: #f4eee0;
 		border: none;
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.2s ease;
 		font-family: "M6X11", sans-serif;
-		font-size: 1.1rem;
-		min-height: 42px;
+		font-size: calc(1.1rem * var(--card-scale, 1));
+		min-height: calc(42px * var(--card-scale, 1));
 		position: relative;
 	}
 
@@ -547,15 +568,15 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		gap: 0.4rem;
-		padding: 0.75rem 0.5rem;
+		gap: calc(0.4rem * var(--card-scale, 1));
+		padding: calc(0.75rem * var(--card-scale, 1)) calc(0.5rem * var(--card-scale, 1));
 		color: #f4eee0;
 		border: none;
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.2s ease;
 		font-family: "M6X11", sans-serif;
-		min-height: 42px;
+		min-height: calc(42px * var(--card-scale, 1));
 		position: relative;
 		background: #56a786;
 		outline: #459373 solid 2px;
@@ -591,9 +612,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		min-width: 42px;
-		height: 42px;
-		padding: 8px;
+		min-width: calc(42px * var(--card-scale, 1));
+		height: calc(42px * var(--card-scale, 1));
+		padding: calc(8px * var(--card-scale, 1));
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.2s ease;
@@ -620,9 +641,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		min-width: 42px;
-		height: 42px;
-		padding: 8px;
+		min-width: calc(42px * var(--card-scale, 1));
+		height: calc(42px * var(--card-scale, 1));
+		padding: calc(8px * var(--card-scale, 1));
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.2s ease;
@@ -630,7 +651,7 @@
 		border: none;
 		flex-shrink: 0;
 		font-family: "M6X11", sans-serif;
-		font-size: 1.1rem;
+		font-size: calc(1.1rem * var(--card-scale, 1));
 	}
 
 	.toggle-button.enabled {
@@ -664,9 +685,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		min-width: 42px;
-		height: 42px;
-		padding: 8px;
+		min-width: calc(42px * var(--card-scale, 1));
+		height: calc(42px * var(--card-scale, 1));
+		padding: calc(8px * var(--card-scale, 1));
 		border-radius: 4px;
 		cursor: pointer;
 		transition: all 0.2s ease;
@@ -704,8 +725,8 @@
 		border: 2px solid rgba(255, 255, 255, 0.3);
 		border-top: 2px solid #ffffff;
 		border-radius: 50%;
-		width: 16px;
-		height: 16px;
+		width: calc(16px * var(--card-scale, 1));
+		height: calc(16px * var(--card-scale, 1));
 		animation: spin 1s linear infinite;
 		margin: 0 auto;
 		display: inline-block;

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -2205,11 +2205,14 @@ onDestroy(() => {
 		margin-top: 3rem !important;
 	}
 
-	.mods-grid {
+    .mods-grid {
 		padding: 1rem 2rem 2rem 2rem;
 		flex: 1;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		grid-template-columns: repeat(
+			auto-fill,
+			minmax(calc(280px * var(--card-scale, 1)), 1fr)
+		);
 		gap: 30px;
 	}
 

--- a/src/components/viewblock/SearchView.svelte
+++ b/src/components/viewblock/SearchView.svelte
@@ -442,7 +442,10 @@ function debounce<T extends (...args: unknown[]) => void>(fn: T, wait: number) {
 		width: 100%;
 		height: 100%;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		grid-template-columns: repeat(
+			auto-fill,
+			minmax(calc(300px * var(--card-scale, 1)), 1fr)
+		);
 		gap: 1rem;
 	}
 

--- a/src/components/viewblock/Settings.svelte
+++ b/src/components/viewblock/Settings.svelte
@@ -5,6 +5,7 @@
 	import { onMount } from "svelte";
 	import { invoke } from "@tauri-apps/api/core";
 	import { backgroundEnabled } from "../../stores/modStore";
+    import { cardScale } from "../../stores/ui";
 
 	let isReindexing = false;
 	let isClearingCache = false;
@@ -260,9 +261,29 @@
 					</label>
 				</div>
 			</div>
+		<p class="description-small">
+			Enable or disable the animated background. Disabling may improve
+			performance on low-end devices.
+		</p>
+
+			<!-- Card size slider -->
+			<div class="slider-row">
+				<div class="slider-label">
+					<span class="label-text">Card Size</span>
+					<span class="value">{Math.round($cardScale * 100)}%</span>
+				</div>
+				<input
+					class="range"
+					type="range"
+					min="0.75"
+					max="1.4"
+					step="0.05"
+					bind:value={$cardScale}
+					aria-label="Card size"
+				/>
+			</div>
 			<p class="description-small">
-				Enable or disable the animated background. Disabling may improve
-				performance on low-end devices.
+				Adjust how large mod cards render. Smaller cards fit more per row.
 			</p>
 
 			<div class="console-settings">
@@ -488,6 +509,94 @@
 	.switch input:checked + .slider:before {
 		transform: translateX(28px);
 	}
+
+	/* Range slider styling */
+    .slider-row {
+        margin-top: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        max-width: 420px;
+    }
+	.slider-label {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		color: #f4eee0;
+		font-size: 1.1rem;
+	}
+    .slider-label .value {
+        color: #fdcf51;
+    }
+    .range {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 100%;
+        height: 28px; /* provide vertical room for thumb */
+        background: transparent; /* move visuals to track */
+        border: 0;
+        box-shadow: none;
+    }
+
+    /* Track visuals */
+    .range::-webkit-slider-runnable-track {
+        height: 12px; /* thicker bar */
+        border-radius: 6px;
+        background: linear-gradient(90deg, #ea9600, #fdcf51);
+        border: 2px solid #f4eee0;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+    }
+    .range::-moz-range-track {
+        height: 12px; /* thicker bar */
+        border-radius: 6px;
+        background: linear-gradient(90deg, #ea9600, #fdcf51);
+        border: 2px solid #f4eee0;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+    }
+    .range::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 20px;
+        height: 20px;
+        border-radius: 4px;
+        background: #f4eee0; /* white thumb */
+        border: 2px solid #9e9a90; /* subtle gray border */
+        box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+        cursor: pointer;
+        position: relative; /* allow offset */
+        margin-top: -4px; /* center 20px thumb over 12px track */
+    }
+    .range::-moz-range-thumb {
+        width: 20px;
+        height: 20px;
+        border-radius: 4px;
+        background: #f4eee0; /* white thumb */
+        border: 2px solid #9e9a90; /* subtle gray border */
+        box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+        cursor: pointer;
+    }
+    .range::-webkit-slider-thumb:hover,
+    .range::-moz-range-thumb:hover {
+        box-shadow: 0 3px 6px rgba(0,0,0,0.3);
+    }
+
+    /* Responsive sizing */
+    @media (max-width: 1160px) {
+        /* Keep slider a comfortable width on smaller screens */
+        .slider-row { max-width: 300px; }
+        .slider-label { font-size: 1rem; }
+        .slider-label .value { font-size: 0.95rem; }
+        .range { height: 24px; }
+        .range::-webkit-slider-runnable-track { height: 10px; }
+        .range::-moz-range-track { height: 10px; }
+        .range::-webkit-slider-thumb {
+            width: 16px; height: 16px; margin-top: -3px; border-radius: 4px;
+        }
+        .range::-moz-range-thumb {
+            width: 16px; height: 16px; border-radius: 4px;
+        }
+    }
+
 	@media (max-width: 1160px) {
 		.switch {
 			width: 50px;

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -24,6 +24,7 @@ let ShaderBackgroundComp = $state<Component | null>(null);
 	import UninstallDialog from "../../components/UninstallDialog.svelte";
 	import { onMount } from "svelte";
 import { lovelyPopupStore } from "../../stores/modStore";
+import { cardScale } from "../../stores/ui";
 import { get } from "svelte/store";
 import ReportIssue from "../../components/ReportIssue.svelte";
 
@@ -280,10 +281,11 @@ import ReportIssue from "../../components/ReportIssue.svelte";
 		</nav>
 	</header>
 
-	<div
+    <div
 		class="content"
 		class:modal-open={!!$currentModView && currentSection == "mods"}
 		bind:this={contentElement}
+        style="--card-scale: {$cardScale}"
 	>
 		<!-- Keep Mods mounted to preserve state and avoid re-fetching
 		     Use display: contents when visible to avoid layout shifts -->

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,0 +1,46 @@
+import { writable } from "svelte/store";
+
+function createPersistentNumber(
+  key: string,
+  fallback: number,
+  opts?: { min?: number; max?: number },
+) {
+  const isBrowser = typeof window !== "undefined";
+  let initial = fallback;
+  if (isBrowser) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw != null) {
+        const n = Number(raw);
+        if (!Number.isNaN(n)) initial = n;
+      }
+    } catch (_) {
+      // ignore storage read errors
+    }
+  }
+  // Clamp to optional bounds
+  if (typeof opts?.min === "number") initial = Math.max(opts.min, initial);
+  if (typeof opts?.max === "number") initial = Math.min(opts.max, initial);
+
+  const store = writable<number>(initial);
+  if (isBrowser) {
+    store.subscribe((val) => {
+      try {
+        let v = val;
+        if (typeof opts?.min === "number") v = Math.max(opts.min, v);
+        if (typeof opts?.max === "number") v = Math.min(opts.max, v);
+        localStorage.setItem(key, String(v));
+      } catch (_) {
+        // ignore storage write errors
+      }
+    });
+  }
+  return store;
+}
+
+// Controls how large mod cards render in the grid/search views
+// Range: 0.75x – 1.4x
+export const cardScale = createPersistentNumber("ui.cardScale", 1, {
+  min: 0.75,
+  max: 1.4,
+});


### PR DESCRIPTION
- Add persistent cardScale store and Settings slider
- Bind --card-scale; scale grids/cards/buttons/text across views
- Dynamic description truncation by scale; clamp and wrapping fixes
- Compact-only title clamp for better small-scale readability
- Installed cards: smaller “Installed” + delete buttons, nudge toggle, compact spacing
- Style slider: white thumb, centered over thicker track; responsive width (capped)