### PR TITLE
feat: add app update check + modal with actions

### DIFF
--- a/src/components/UpdateAvailablePopup.svelte
+++ b/src/components/UpdateAvailablePopup.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import { fade, scale } from "svelte/transition";
+  import { onMount, onDestroy } from "svelte";
+  import { open } from "@tauri-apps/plugin-shell";
+
+  export let visible: boolean = false;
+  export let currentVersion: string = "";
+  export let latestVersion: string = "";
+  export let onClose: () => void;
+  export let onDontShow: () => void;
+
+  async function handleDownload() {
+    try {
+      await open("https://balatro-mod-manager.dasguney.com/download");
+    } catch (e) {
+      console.error("Failed to open download page:", e);
+    }
+    onClose();
+  }
+
+  let keyHandler: ((e: KeyboardEvent) => void) | null = null;
+  onMount(() => {
+    keyHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && visible) {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", keyHandler);
+  });
+  onDestroy(() => {
+    if (keyHandler) window.removeEventListener("keydown", keyHandler);
+  });
+</script>
+
+{#if visible}
+  <div class="modal-background" transition:fade={{ duration: 100 }}>
+    <div class="modal" transition:scale={{ duration: 200, start: 0.95, opacity: 1 }}>
+      <h2>Update Available</h2>
+      <p>
+        A newer version of Balatro Mod Manager is available.
+      </p>
+      <p class="ver">
+        Current: <span class="version">v{currentVersion}</span> •
+        Latest: <span class="version">v{latestVersion}</span>
+      </p>
+
+      <div class="buttons">
+        <button class="download-button" on:click={handleDownload}>Download</button>
+        <button class="close-button" on:click={onClose}>Close</button>
+        <button class="dontshow-button" on:click={onDontShow}>Don't show anymore</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+  }
+  .modal {
+    background: #2d2d2d;
+    outline: 2px solid #56a786;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.7);
+    max-width: 420px;
+    width: 86%;
+    text-align: center;
+  }
+  h2 {
+    color: #56a786;
+    margin-bottom: 0.75rem;
+    font-family: "M6X11", sans-serif;
+  }
+  p, .ver {
+    color: #f4eee0;
+    font-size: 1.1rem;
+    font-family: "M6X11", sans-serif;
+    margin: 0.25rem 0 0.75rem 0;
+  }
+  .ver .version { color: #fdcf51; }
+  .buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+  }
+  button {
+    padding: 0.6rem 1.2rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: all 0.2s ease;
+    font-family: "M6X11", sans-serif;
+    color: #fff;
+  }
+  .download-button { background: #3498db; outline: #2980b9 solid 2px; }
+  .close-button { background: #56a786; outline: #74cca8 solid 2px; }
+  .dontshow-button { background: #c14139; outline: #a13029 solid 2px; }
+  button:hover { opacity: 0.9; transform: translateY(-1px); }
+</style>

--- a/src/stores/update.ts
+++ b/src/stores/update.ts
@@ -1,0 +1,31 @@
+import { writable } from "svelte/store";
+
+function createPersistentBoolean(key: string, fallback: boolean) {
+  const isBrowser = typeof window !== "undefined";
+  let initial = fallback;
+  if (isBrowser) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw != null) initial = raw === "true";
+    } catch (_) {
+      // ignore
+    }
+  }
+  const store = writable<boolean>(initial);
+  if (isBrowser) {
+    store.subscribe((val) => {
+      try {
+        localStorage.setItem(key, val ? "true" : "false");
+      } catch (_) {
+        // ignore
+      }
+    });
+  }
+  return store;
+}
+
+// If true, never show the update-available popup
+export const updatePromptDisabled = createPersistentBoolean(
+  "ui.updatePromptDisabled",
+  false,
+);


### PR DESCRIPTION
- Check latest version via GitHub tags (fallback to releases list); compare to current
- Show UpdateAvailablePopup with Download, Close, Don’t show anymore
- Persist “don’t show” in localStorage (ui.updatePromptDisabled)
- Wire check on startup in +layout; log latest version to console
- Tweak modal width and spacing; only version numbers in yellow
- Close modal on Escape
- Fix Svelte 5 runes issues in layout (use $props, children render)