### PR TITLE
258 periodically validate mod database

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,7 +94,7 @@ pub fn run() {
                 use std::time::Duration;
                 use tokio::time::sleep;
 
-                const REINDEX_TICK_SECS: u64 = 3; // can drop to 1s if desired
+                const REINDEX_TICK_SECS: u64 = 1; // 1s polling for quick updates
                 const REINDEX_BATCH_SIZE: usize = 5; // small batch to keep cost negligible
 
                 // Snapshot of installed mods to sweep over between refreshes

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -374,6 +374,7 @@ const { handleDependencyCheck, mod } = $props<{
 				if ($currentCategory === "Installed Mods") {
 					try {
 						await refreshInstalledMods();
+						await getLocalMods();
 					} catch {}
 				}
 			})

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -1663,13 +1663,7 @@ onDestroy(() => {
 										(outside the mod manager)
 									</p>
 								</div>
-								<button
-									class="open-folder-button"
-									onclick={openModsFolder}
-									title="Open mods folder"
-								>
-									<Folder size={20} /> Open Mods Folder
-								</button>
+								<!-- Removed Open Mods Folder button for Local Mods section -->
 							</div>
 
 							<!-- Enabled Local Mods -->
@@ -1731,13 +1725,7 @@ onDestroy(() => {
 										catalog
 									</p>
 								</div>
-								<button
-									class="open-folder-button"
-									onclick={openModsFolder}
-									title="Open mods folder"
-								>
-									<Folder size={20} /> Open Mods Folder
-								</button>
+								<!-- Removed Open Mods Folder button for Mod Manager Catalog section -->
 							</div>
 						{:else if !isLoadingLocalMods && localMods.length === 0 && paginatedMods.length === 0}
 							<div class="no-mods-message">


### PR DESCRIPTION
This pull request introduces real-time synchronization between the backend mod database and the frontend UI, ensuring that changes to installed mods (such as file deletions or additions) are reflected immediately in the app. The backend now periodically and incrementally validates the mod database, emits notifications when changes are detected, and the frontend listens for these events to refresh its data. Additionally, some UI cleanup was performed by removing redundant "Open Mods Folder" buttons.

**Backend: Real-time mod database validation and event emission**
* Added a background task in `src-tauri/src/lib.rs` that periodically (every second) sweeps the mod database for missing files in small batches, removes stale entries, and emits an `installed-mods-changed` event to notify the UI of any changes. This includes a fingerprint mechanism to detect additions/removals in the mods directory.
* Refactored `reindex_mods` in `src-tauri/src/commands/detection.rs` to emit an `installed-mods-changed` event when database entries are cleaned, and extracted the core logic into a reusable `reindex_db` function.
* Updated imports in backend files to support new functionality. [[1]](diffhunk://#diff-0398506030d89a9b9b315066c57b1ebcda0305052cadc95134452cc42ff1b09bL5-R7) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL13-R15)

**Frontend: UI auto-refresh and event listening**
* Added listeners in `src/components/viewblock/Mods.svelte` and `src/stores/modCache.ts` to respond to the `installed-mods-changed` event by refreshing installed mods and cache, ensuring real-time UI updates. Includes safeguards against duplicate listeners during development hot-reload. [[1]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR41) [[2]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR371-R389) [[3]](diffhunk://#diff-eac406aaf413cf25865220d435173d99fb31e51f4168a135e3305410fdb8f66aR4-R13) [[4]](diffhunk://#diff-eac406aaf413cf25865220d435173d99fb31e51f4168a135e3305410fdb8f66aR91-R124)

**UI cleanup**
* Removed redundant "Open Mods Folder" buttons from the Local Mods and Mod Manager Catalog sections in `Mods.svelte` for a cleaner interface. [[1]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL1650-R1667) [[2]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL1718-R1729)