### PR TITLE
Allow special characters in thumbnail file names

### DIFF
--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -522,11 +522,39 @@ pub async fn fetch_gitlab_mods_meta_only() -> Result<Vec<ArchiveModItem>, String
     Ok(items)
 }
 
+fn is_legal_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(
+            c,
+            '!' | '#'
+                | '$'
+                | '%'
+                | '&'
+                | '\''
+                | '('
+                | ')'
+                | '+'
+                | ','
+                | '-'
+                | '='
+                | ';'
+                | '@'
+                | '['
+                | ']'
+                | '^'
+                | '_'
+                | '`'
+                | '{'
+                | '}'
+                | '~'
+        )
+}
+
 fn safe_slug(input: &str) -> String {
     let mut s = input.trim().to_lowercase();
     s = s
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .map(|c| if is_legal_char(c) { c } else { '-' })
         .collect();
     while s.contains("--") {
         s = s.replace("--", "-");


### PR DESCRIPTION
Thumbnail (and description) file names currently replace all special characters, even though many are supported by file systems

This currently causes collisions between ["Pokermon" and "Pokermon+"](https://github.com/skyline69/balatro-mod-manager/issues/265), who both take on whichever thumbnail loaded first instead of having their own

(Note: this PR adds *all* allowed characters on modern systems, bar space and period for windows concerns, and the list should be vetted to ensure none of them cause issues)