### PR TITLE
fix: detect Snap/Flatpak Steam paths on Linux

### DIFF
--- a/src-tauri/bmm-lib/src/finder.rs
+++ b/src-tauri/bmm-lib/src/finder.rs
@@ -1,12 +1,16 @@
 use crate::database::Database;
 use log::error;
 use log::info;
+#[cfg(target_os = "linux")]
+use regex::Regex;
 use std::collections::HashSet;
 #[cfg(target_os = "windows")]
 use std::fs::File;
 #[cfg(target_os = "windows")]
 use std::io::{BufReader, Read};
 #[cfg(target_os = "windows")]
+use std::path::Path;
+#[cfg(target_os = "linux")]
 use std::path::Path;
 use std::path::PathBuf;
 #[cfg(target_os = "windows")]
@@ -146,6 +150,35 @@ pub fn get_balatro_paths() -> Vec<PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
+fn parse_libraryfolders(library_path: &Path) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    let contents = match std::fs::read_to_string(library_path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                "Failed to read libraryfolders.vdf at {}: {}",
+                library_path.to_string_lossy(),
+                e
+            );
+            return results;
+        }
+    };
+
+    // Matches lines like: "path"    "/mnt/games/SteamLibrary"
+    let re = Regex::new(r#""path"\s*"([^"]+)""#).unwrap();
+    for caps in re.captures_iter(&contents) {
+        if let Some(path_match) = caps.get(1) {
+            let path_str = path_match.as_str();
+            // Normalize escaped backslashes in case they appear
+            let cleaned = path_str.replace("\\\\", "\\");
+            results.push(PathBuf::from(cleaned).join("steamapps/common/Balatro"));
+        }
+    }
+
+    results
+}
+
+#[cfg(target_os = "linux")]
 pub fn get_balatro_paths() -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = vec![];
 
@@ -158,14 +191,37 @@ pub fn get_balatro_paths() -> Vec<PathBuf> {
             }
         }
     }
+
+    let mut steam_roots: Vec<PathBuf> = Vec::new();
+    let mut seen_roots: HashSet<String> = HashSet::new();
+    let mut add_root = |root: PathBuf| {
+        let key = root.to_string_lossy().to_string().to_lowercase();
+        if seen_roots.insert(key) {
+            steam_roots.push(root);
+        }
+    };
+
     match home::home_dir() {
-        Some(path) => {
-            let mut path = path;
-            path.push(".local/share/Steam/steamapps/common/Balatro");
-            paths.push(path);
+        Some(home) => {
+            add_root(home.join(".local/share/Steam"));
+            add_root(home.join(".steam/steam"));
+            add_root(home.join(".var/app/com.valvesoftware.Steam/data/Steam"));
+            // Snap installs keep the real Steam data under this prefix.
+            add_root(home.join("snap/steam/common/.local/share/Steam"));
         }
         None => error!("Impossible to get your home dir!"),
     }
+
+    for root in steam_roots {
+        let steamapps = root.join("steamapps");
+        paths.push(steamapps.join("common/Balatro"));
+
+        let libraryfolders = steamapps.join("libraryfolders.vdf");
+        if libraryfolders.exists() {
+            paths.extend(parse_libraryfolders(&libraryfolders));
+        }
+    }
+
     remove_unexisting_paths(&mut paths);
     dedup_paths_case_insensitive(&mut paths);
     paths

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,100 +1,93 @@
 {
-    "$schema": "https://schema.tauri.app/config/2",
-    "productName": "Balatro Mod Manager",
-    "version": "0.3.0",
-    "identifier": "com.balatro-mod-manager.app",
-    "build": {
-        "beforeDevCommand": "bun run dev",
-        "devUrl": "http://localhost:1420",
-        "beforeBuildCommand": "bun run build",
-        "frontendDist": "../build"
-    },
-    "app": {
-        "windows": [
-            {
-                "title": "Balatro Mod Manager",
-                "width": 1035,
-                "height": 750,
-                "minWidth": 1035,
-                "minHeight": 750,
-                "resizable": true,
-                "visible": false
-            }
-        ],
-        "security": {
-            "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost file: data: http: https:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost https:",
-            "assetProtocol": {
-                "enable": true,
-                "scope": [
-                    "$APPDIR/**",
-                    "$RESOURCE/**",
-                    "$CONFIG/**",
-                    "$CONFIG/Balatro/**",
-                    "$APPDATA/Balatro/**",
-                    "$HOME/AppData/Roaming/Balatro/**",
-                    "$HOME/.config/Balatro/**",
-                    "$HOME/Library/Application Support/Balatro/**"
-                ]
-            }
-        }
-    },
-    "bundle": {
-        "active": true,
-        "targets": "all",
-        "icon": [
-            "icons/32x32.png",
-            "icons/128x128.png",
-            "icons/128x128@2x.png",
-            "icons/icon.icns",
-            "icons/icon.ico"
-        ],
-        "resources": [
-            "../static/fonts",
-            "../static/images"
-        ],
-        "macOS": {
-            "entitlements": "Entitlements.plist",
-            "minimumSystemVersion": "11.0",
-            "signingIdentity": null,
-            "providerShortName": null,
-            "frameworks": []
-        },
-        "windows": {
-            "webviewInstallMode": {
-                "type": "embedBootstrapper"
-            }
-        }
-    },
-    "plugins": {
-        "shell": {
-            "open": true
-        },
-        "window": {
-            "create": true,
-            "close": true,
-            "maximize": true,
-            "minimize": true,
-            "unmaximize": true,
-            "unminimize": true,
-            "startDragging": true
-        },
-        "allowlist": {
-            "menu": {
-                "all": true
-            },
-            "path": {
-                "all": true
-            },
-            "fs": {
-                "scope": [
-                    "$RESOURCE/**",
-                    "$ASSET/**",
-                    "$CONFIG/**"
-                ]
-            },
-            "window": {
-                "show": true
-            }
-        }
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Balatro Mod Manager",
+  "version": "0.3.0",
+  "identifier": "com.balatro-mod-manager.app",
+  "build": {
+    "beforeDevCommand": "bun run dev",
+    "devUrl": "http://localhost:1420",
+    "beforeBuildCommand": "bun run build",
+    "frontendDist": "../build"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Balatro Mod Manager",
+        "width": 1035,
+        "height": 750,
+        "minWidth": 1035,
+        "minHeight": 750,
+        "resizable": true,
+        "visible": false
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost file: data: http: https:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost https:",
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "$APPDIR/**",
+          "$RESOURCE/**",
+          "$CONFIG/**",
+          "$CONFIG/Balatro/**",
+          "$APPDATA/Balatro/**",
+          "$HOME/AppData/Roaming/Balatro/**",
+          "$HOME/.config/Balatro/**",
+          "$HOME/Library/Application Support/Balatro/**"
+        ]
+      }
     }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "resources": ["../static/fonts", "../static/images"],
+    "macOS": {
+      "entitlements": "Entitlements.plist",
+      "minimumSystemVersion": "11.0",
+      "signingIdentity": null,
+      "providerShortName": null,
+      "frameworks": []
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper"
+      }
+    }
+  },
+  "plugins": {
+    "shell": {
+      "open": true
+    },
+    "window": {
+      "create": true,
+      "close": true,
+      "maximize": true,
+      "minimize": true,
+      "unmaximize": true,
+      "unminimize": true,
+      "startDragging": true
+    },
+    "allowlist": {
+      "menu": {
+        "all": true
+      },
+      "path": {
+        "all": true
+      },
+      "fs": {
+        "scope": ["$RESOURCE/**", "$ASSET/**", "$CONFIG/**"]
+      },
+      "window": {
+        "show": true
+      }
+    }
+  }
 }


### PR DESCRIPTION
This pull request improves the detection of Balatro installation directories on Linux by adding robust parsing of Steam's `libraryfolders.vdf` file, ensuring support for multiple Steam library locations and various installation methods. It also includes minor formatting changes to the Tauri configuration file for consistency.

**Linux Steam library detection improvements:**

* Added a new `parse_libraryfolders` function to extract additional Steam library paths from `libraryfolders.vdf`, supporting detection of Balatro installations in non-default Steam libraries.
* Enhanced `get_balatro_paths` on Linux to:
  - Aggregate possible Steam root directories, including Flatpak, Snap, and standard installations.
  - Use a hash set to avoid duplicate paths.
  - Parse `libraryfolders.vdf` for each Steam root to find all possible Balatro install locations.
* Added necessary imports for `Regex` and `Path` on Linux to support the new parsing logic.

**Configuration formatting:**

* Reformatted the `resources` and `fs.scope` sections in `tauri.conf.json` for improved readability and consistency. [[1]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L51-R51) [[2]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L89-R86)