### PR TITLE
feature: add flatpak support for steamos and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ node_modules
 /build
 /.svelte-kit
 /package
+/build-dir
+/.flatpak-builder
+/repo
+/balatro-mod-manager.flatpak
 .env
 .env.*
 !.env.example

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ Scroll down to find **▸Assets** and download the right version of the installe
 - macOS: `Balatro.Mod.Manager_…_universal.dmg`
 - Linux: `Balatro.Mod.Manager_…_amd64.AppImage` (mark as executable if needed)
 
+## Flatpak (Steam Deck/Linux)
+
+- Install runtimes once (GNOME 47 + toolchain extensions):
+  ```bash
+  flatpak install org.gnome.Platform//47 org.gnome.Sdk//47 \
+    org.freedesktop.Sdk.Extension.node20//24.08 \
+    org.freedesktop.Sdk.Extension.rust-stable//24.08
+  ```
+- Build + bundle from this repo:
+  ```bash
+  flatpak-builder --force-clean --repo=repo build-dir packaging/flatpak/io.balatro.ModManager.json
+  flatpak build-bundle repo balatro-mod-manager.flatpak io.balatro.ModManager master
+  ```
+- Install/run (on the Deck or any Flatpak host):
+  ```bash
+  flatpak install --user balatro-mod-manager.flatpak
+  flatpak run io.balatro.ModManager
+  ```
+AppImage/Deb/RPM still land in `target/release/bundle/` during the Flatpak build if you need them.
+
 # [![Build](images/build.svg)](#build-prerequisites)
 
 Alternatively, if you would prefer to build Balatro Mod Manager yourself instead of downloading the [prebuilt installer](https://github.com/skyline69/balatro-mod-manager/releases/latest), Balatro Mod Manager can be compiled from source using the instructions below.

--- a/packaging/flatpak/io.balatro.ModManager.desktop
+++ b/packaging/flatpak/io.balatro.ModManager.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Balatro Mod Manager
+Exec=balatro-mod-manager
+Icon=io.balatro.ModManager
+Terminal=false
+Type=Application
+Categories=Game;Utility;
+StartupWMClass=Balatro Mod Manager

--- a/packaging/flatpak/io.balatro.ModManager.json
+++ b/packaging/flatpak/io.balatro.ModManager.json
@@ -1,0 +1,68 @@
+{
+  "app-id": "io.balatro.ModManager",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "47",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.node20",
+    "org.freedesktop.Sdk.Extension.rust-stable"
+  ],
+  "command": "balatro-mod-manager",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--share=network",
+    "--filesystem=xdg-config/Balatro",
+    "--filesystem=xdg-data/Balatro",
+    "--filesystem=home/.local/share/Steam",
+    "--filesystem=home/.steam"
+  ],
+  "modules": [
+    {
+      "name": "balatro-mod-manager",
+      "buildsystem": "simple",
+      "build-options": {
+        "append-path": "/usr/lib/sdk/node20/bin:/usr/lib/sdk/rust-stable/bin",
+        "env": {
+          "CARGO_TARGET_DIR": "/run/build/balatro-mod-manager/target",
+          "npm_config_cache": "/run/build/balatro-mod-manager/.npm",
+          "NPM_CONFIG_FUND": "false",
+          "NPM_CONFIG_AUDIT": "false"
+        },
+        "build-args": [
+          "--share=network"
+        ]
+      },
+      "build-commands": [
+        "cd /run/build/balatro-mod-manager && export CARGO_HOME=/run/build/balatro-mod-manager/.cargo && export PATH=\"$CARGO_HOME/bin:$PATH\" && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash",
+        "cd /run/build/balatro-mod-manager && export CARGO_HOME=/run/build/balatro-mod-manager/.cargo && export PATH=\"$CARGO_HOME/bin:$PATH\" && cargo binstall tauri-cli -y --force",
+        "cd /run/build/balatro-mod-manager && export BUN_INSTALL=/run/build/balatro-mod-manager/.bun && curl -fsSL https://bun.sh/install | bash",
+        "cd /run/build/balatro-mod-manager && export BUN_INSTALL=/run/build/balatro-mod-manager/.bun && export PATH=\"$BUN_INSTALL/bin:$PATH\" && bun install",
+        "cd /run/build/balatro-mod-manager && export BUN_INSTALL=/run/build/balatro-mod-manager/.bun && export PATH=\"$BUN_INSTALL/bin:$PATH\" && bun run build",
+        "cd /run/build/balatro-mod-manager/src-tauri && export CARGO_HOME=/run/build/balatro-mod-manager/.cargo && export BUN_INSTALL=/run/build/balatro-mod-manager/.bun && export PATH=\"$BUN_INSTALL/bin:$CARGO_HOME/bin:$PATH\" && cargo tauri build --bundles deb rpm appimage",
+        "cd /run/build/balatro-mod-manager && install -Dm755 target/release/BMM /app/bin/balatro-mod-manager",
+        "install -Dm644 packaging/flatpak/io.balatro.ModManager.desktop /app/share/applications/io.balatro.ModManager.desktop",
+        "install -Dm644 packaging/flatpak/io.balatro.ModManager.metainfo.xml /app/share/metainfo/io.balatro.ModManager.metainfo.xml",
+        "install -Dm644 src-tauri/icons/512x512.png /app/share/icons/hicolor/512x512/apps/io.balatro.ModManager.png"
+      ],
+      "sources": [
+        {
+          "type": "dir",
+          "path": "../..",
+          "dest": ".",
+          "skip": [
+            ".flatpak-builder",
+            ".git",
+            "build",
+            "node_modules",
+            "repo",
+            "squashfs-root",
+            "target"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packaging/flatpak/io.balatro.ModManager.metainfo.xml
+++ b/packaging/flatpak/io.balatro.ModManager.metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.balatro.ModManager</id>
+  <name>Balatro Mod Manager</name>
+  <summary>Install and manage Balatro mods</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <launchable type="desktop-id">io.balatro.ModManager.desktop</launchable>
+  <developer_name>skyline69</developer_name>
+  <provides>
+    <binary>balatro-mod-manager</binary>
+  </provides>
+  <description>
+    <p>Balatro Mod Manager lets you install, update, and manage Balatro mods with one-click installs, built-in backups, and automatic Lovely setup.</p>
+    <ul>
+      <li>Browse and install curated mods with version tracking.</li>
+      <li>Detect and manage your existing mods and keep Lovely current.</li>
+      <li>Backup/restore mod lists and quickly clean up broken installs.</li>
+      <li>Steam Deck friendly: works in Gaming/Desktop mode with no extra system packages.</li>
+    </ul>
+  </description>
+  <url type="homepage">https://github.com/skyline69/balatro-mod-manager</url>
+  <releases>
+    <release version="0.3.0"/>
+  </releases>
+</component>


### PR DESCRIPTION
This pull request adds Flatpak packaging support for Balatro Mod Manager, making it easier to build, distribute, and install the app on Steam Deck and other Linux systems. The changes introduce new Flatpak manifest and metadata files, update the documentation with Flatpak build and install instructions, and ensure proper desktop integration.

**Flatpak packaging and distribution:**

* Added a Flatpak manifest (`io.balatro.ModManager.json`) to automate building the app and its dependencies for Flatpak, including runtime, SDK, and build steps.
* Added a desktop entry file (`io.balatro.ModManager.desktop`) for proper application launch and desktop environment integration.
* Added a metainfo XML file (`io.balatro.ModManager.metainfo.xml`) for AppStream metadata, improving discoverability in software centers.

**Documentation updates:**

* Updated `README.md` with detailed Flatpak build and installation instructions for Linux and Steam Deck users, including required runtimes and build commands.