### PR TITLE
fix: preserve mod enabled state on update

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,5 @@ coverage
 .vercel
 .netlify
 
+
+.flatpak-builder/**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Scroll down to find **▸Assets** and download the right version of the installe
 - Linux: `Balatro.Mod.Manager_…_amd64.AppImage` (mark as executable if needed)
 
 ## Flatpak (Steam Deck/Linux)
-> You need [flatpak-builder](https://docs.flatpak.org/de/latest/flatpak-builder.html) for this. 
+
+> You need [flatpak-builder](https://docs.flatpak.org/de/latest/flatpak-builder.html) for this.
+
 - Run from a local checkout:
   ```bash
   git clone https://github.com/skyline69/balatro-mod-manager.git
@@ -49,7 +51,7 @@ Scroll down to find **▸Assets** and download the right version of the installe
   flatpak install --user balatro-mod-manager.flatpak
   flatpak run io.balatro.ModManager
   ```
-AppImage/Deb/RPM still land in `target/release/bundle/` during the Flatpak build if you need them.
+  AppImage/Deb/RPM still land in `target/release/bundle/` during the Flatpak build if you need them.
 
 # [![Build](images/build.svg)](#build-prerequisites)
 

--- a/packaging/flatpak/io.balatro.ModManager.json
+++ b/packaging/flatpak/io.balatro.ModManager.json
@@ -35,9 +35,7 @@
           "NPM_CONFIG_FUND": "false",
           "NPM_CONFIG_AUDIT": "false"
         },
-        "build-args": [
-          "--share=network"
-        ]
+        "build-args": ["--share=network"]
       },
       "build-commands": [
         "cd /run/build/balatro-mod-manager && export CARGO_HOME=/run/build/balatro-mod-manager/.cargo && export PATH=\"$CARGO_HOME/bin:$PATH\" && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash",

--- a/src-tauri/bmm-lib/src/cache.rs
+++ b/src-tauri/bmm-lib/src/cache.rs
@@ -355,28 +355,37 @@ pub fn load_cache() -> Result<Option<(Vec<Mod>, u64)>, AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use tempfile::tempdir;
+
+    fn set_var(key: &str, val: impl AsRef<OsStr>) {
+        unsafe { std::env::set_var(key, val) };
+    }
+
+    fn remove_var(key: &str) {
+        unsafe { std::env::remove_var(key) };
+    }
 
     fn with_temp_cache<T>(test: impl FnOnce(PathBuf) -> T) -> T {
         let temp_dir = tempdir().unwrap();
         let original_cache = std::env::var_os("XDG_CACHE_HOME");
         let original_home = std::env::var_os("HOME");
 
-        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        set_var("XDG_CACHE_HOME", temp_dir.path());
         // On macOS, dirs::cache_dir uses ~/Library/Caches, so set HOME to our temp dir
         if cfg!(target_os = "macos") {
-            std::env::set_var("HOME", temp_dir.path());
+            set_var("HOME", temp_dir.path());
         }
         let result = test(temp_dir.path().to_path_buf());
 
         // restore env
         match original_cache {
-            Some(val) => std::env::set_var("XDG_CACHE_HOME", val),
-            None => std::env::remove_var("XDG_CACHE_HOME"),
+            Some(val) => set_var("XDG_CACHE_HOME", val),
+            None => remove_var("XDG_CACHE_HOME"),
         }
         match original_home {
-            Some(val) => std::env::set_var("HOME", val),
-            None => std::env::remove_var("HOME"),
+            Some(val) => set_var("HOME", val),
+            None => remove_var("HOME"),
         }
 
         result

--- a/src-tauri/bmm-lib/src/finder.rs
+++ b/src-tauri/bmm-lib/src/finder.rs
@@ -375,7 +375,16 @@ pub fn is_balatro_running() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
     use tempfile::tempdir;
+
+    fn set_var(key: &str, val: impl AsRef<OsStr>) {
+        unsafe { std::env::set_var(key, val) };
+    }
+
+    fn remove_var(key: &str) {
+        unsafe { std::env::remove_var(key) };
+    }
 
     #[test]
     fn test_get_installed_mods_filters_lovely_dirs() {
@@ -383,9 +392,9 @@ mod tests {
         // Redirect config dir to temp using XDG_CONFIG_HOME and HOME (for macOS)
         let original_cfg = std::env::var_os("XDG_CONFIG_HOME");
         let original_home = std::env::var_os("HOME");
-        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+        set_var("XDG_CONFIG_HOME", tmp.path());
         if cfg!(target_os = "macos") {
-            std::env::set_var("HOME", tmp.path());
+            set_var("HOME", tmp.path());
         }
 
         let mods_root = dirs::config_dir().unwrap().join("Balatro").join("Mods");
@@ -412,12 +421,12 @@ mod tests {
 
         // restore environment
         match original_cfg {
-            Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
+            Some(val) => set_var("XDG_CONFIG_HOME", val),
+            None => remove_var("XDG_CONFIG_HOME"),
         }
         match original_home {
-            Some(val) => std::env::set_var("HOME", val),
-            None => std::env::remove_var("HOME"),
+            Some(val) => set_var("HOME", val),
+            None => remove_var("HOME"),
         }
     }
 }

--- a/src-tauri/bmm-lib/src/installer.rs
+++ b/src-tauri/bmm-lib/src/installer.rs
@@ -95,6 +95,7 @@ pub async fn install_mod(url: String, folder_name: Option<String>) -> Result<Pat
 
     // Uninstall old mod folder if it exists
     let target_dir = mod_dir.join(&mod_name);
+    let was_disabled = target_dir.join(".lovelyignore").exists();
     if target_dir.exists() {
         log::info!("Uninstalling existing mod at: {target_dir:?}");
         uninstall_mod(target_dir.clone())?;
@@ -107,6 +108,11 @@ pub async fn install_mod(url: String, folder_name: Option<String>) -> Result<Pat
         ArchiveKind::Tar => handle_tar(file, &mod_dir, &mod_name)?,
         ArchiveKind::TarGz => handle_tar_gz(file, &mod_dir, &mod_name)?,
     };
+
+    if was_disabled {
+        log::info!("Restoring disabled state for {}", installed_path.display());
+        apply_disabled_marker(&installed_path)?;
+    }
 
     log::info!("Mod installed successfully at: {installed_path:?}");
     Ok(installed_path)
@@ -465,6 +471,34 @@ fn ensure_safe_path(base: &Path, path: &Path) -> Result<(), AppError> {
     }
 }
 
+fn apply_disabled_marker(mod_path: &Path) -> Result<(), AppError> {
+    let entries = fs::read_dir(mod_path).map_err(|e| AppError::FileRead {
+        path: mod_path.to_path_buf(),
+        source: e.to_string(),
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| AppError::FileRead {
+            path: mod_path.to_path_buf(),
+            source: e.to_string(),
+        })?;
+        let entry_path = entry.path();
+        if entry_path.is_dir() {
+            let ignore_path = entry_path.join(".lovelyignore");
+            fs::write(&ignore_path, "").map_err(|e| AppError::FileWrite {
+                path: ignore_path,
+                source: e.to_string(),
+            })?;
+        }
+    }
+
+    let top_level_ignore = mod_path.join(".lovelyignore");
+    fs::write(&top_level_ignore, "").map_err(|e| AppError::FileWrite {
+        path: top_level_ignore,
+        source: e.to_string(),
+    })
+}
+
 pub fn uninstall_mod(path: PathBuf) -> Result<(), AppError> {
     log::info!("Uninstalling mod: {path:?}");
 
@@ -604,5 +638,21 @@ mod tests {
         // Should not allow deleting Mods root
         let res = validate_uninstall_path(&mods_dir.clone(), &mods_dir.clone());
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn apply_disabled_marker_creates_ignore_files() {
+        let td = tempdir().unwrap();
+        let mod_dir = td.path().join("ExampleMod");
+        std::fs::create_dir_all(mod_dir.join("sub1")).unwrap();
+        std::fs::create_dir_all(mod_dir.join("sub2/nested")).unwrap();
+
+        apply_disabled_marker(&mod_dir).unwrap();
+
+        assert!(mod_dir.join(".lovelyignore").exists());
+        assert!(mod_dir.join("sub1/.lovelyignore").exists());
+        assert!(mod_dir.join("sub2/.lovelyignore").exists());
+        // Nested directories aren't touched directly; parent markers should suffice
+        assert!(!mod_dir.join("sub2/nested/.lovelyignore").exists());
     }
 }

--- a/src-tauri/src/commands/detection.rs
+++ b/src-tauri/src/commands/detection.rs
@@ -115,7 +115,16 @@ pub fn reindex_db(db: &Database) -> Result<(usize, usize), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use tempfile::tempdir;
+
+    fn set_var(key: &str, val: impl AsRef<OsStr>) {
+        unsafe { std::env::set_var(key, val) };
+    }
+
+    fn remove_var(key: &str) {
+        unsafe { std::env::remove_var(key) };
+    }
 
     #[test]
     fn reindex_db_removes_missing_paths() {
@@ -123,9 +132,9 @@ mod tests {
         let td = tempdir().unwrap();
         let original_cfg = std::env::var_os("XDG_CONFIG_HOME");
         let original_home = std::env::var_os("HOME");
-        std::env::set_var("XDG_CONFIG_HOME", td.path());
+        set_var("XDG_CONFIG_HOME", td.path());
         if cfg!(target_os = "macos") {
-            std::env::set_var("HOME", td.path());
+            set_var("HOME", td.path());
         }
 
         let db = Database::new().expect("db");
@@ -151,12 +160,12 @@ mod tests {
 
         // restore env
         match original_cfg {
-            Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
+            Some(val) => set_var("XDG_CONFIG_HOME", val),
+            None => remove_var("XDG_CONFIG_HOME"),
         }
         match original_home {
-            Some(val) => std::env::set_var("HOME", val),
-            None => std::env::remove_var("HOME"),
+            Some(val) => set_var("HOME", val),
+            None => remove_var("HOME"),
         }
     }
 }

--- a/src/components/viewblock/ModCard.svelte
+++ b/src/components/viewblock/ModCard.svelte
@@ -183,6 +183,31 @@ import { isLinuxPlatform } from "$lib/platform";
 	}
 
 	async function installModFromURL(url: string, folder_name: string = "") {
+		const wasInstalled = Boolean($installationStatus[mod.title]);
+		let desiredEnabledState = true;
+
+		if (wasInstalled) {
+			let previousEnabled = $modEnabledStore[mod.title];
+			if (previousEnabled === undefined) {
+				try {
+					previousEnabled = await invoke<boolean>("is_mod_enabled", {
+						modName: mod.title,
+					});
+				} catch (error) {
+					console.error(
+						`Failed to read existing enabled state for ${mod.title}:`,
+						error,
+					);
+				}
+			}
+
+			if (previousEnabled !== undefined) {
+				desiredEnabledState = previousEnabled;
+			} else {
+				desiredEnabledState = isEnabled;
+			}
+		}
+
 		try {
 			loadingStates.update((s) => ({ ...s, [mod.title]: true }));
 
@@ -226,12 +251,11 @@ import { isLinuxPlatform } from "$lib/platform";
 				[mod.title]: false,
 			}));
 
-			// Set newly installed mod as enabled by default
 			modEnabledStore.update((enabledMods) => ({
 				...enabledMods,
-				[mod.title]: true,
+				[mod.title]: desiredEnabledState,
 			}));
-			isEnabled = true;
+			isEnabled = desiredEnabledState;
 
 			// Manually check mod enabled status after installation
 			setTimeout(() => checkModEnabled(mod.title), 500);

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -516,6 +516,30 @@ const { handleDependencyCheck, mod } = $props<{
 				return;
 			}
 
+			const previousEnabledMap: Record<string, boolean> = Object.fromEntries(
+				await Promise.all(
+					modsToUpdate.map(async (mod) => {
+						const cached = $modEnabledStore?.[mod.title];
+						if (cached !== undefined) {
+							return [mod.title, cached] as const;
+						}
+
+						try {
+							const enabled = await invoke<boolean>("is_mod_enabled", {
+								modName: mod.title,
+							});
+							return [mod.title, enabled] as const;
+						} catch (error) {
+							console.error(
+								`Failed to read enabled state for ${mod.title}:`,
+								error,
+							);
+							return [mod.title, true] as const;
+						}
+					}),
+				),
+			);
+
 			// Set loading state for all mods simultaneously
 			for (const mod of modsToUpdate) {
 				loadingStates2.update((s) => ({ ...s, [mod.title]: true }));
@@ -586,8 +610,10 @@ const { handleDependencyCheck, mod } = $props<{
 						...s,
 						[modTitle]: false,
 					}));
-					// Ensure it stays enabled
-					modEnabledStore.update((s) => ({ ...s, [modTitle]: true }));
+					modEnabledStore.update((s) => ({
+						...s,
+						[modTitle]: previousEnabledMap[modTitle],
+					}));
 				} else {
 					failed.push(modTitle);
 					// Show error message
@@ -620,6 +646,29 @@ const { handleDependencyCheck, mod } = $props<{
 		url: string,
 		folder_name: string = "",
 	) {
+		const wasInstalled = Boolean($installationStatus[mod.title]);
+		let desiredEnabledState = true;
+
+		if (wasInstalled) {
+			let previousEnabled = $modEnabledStore?.[mod.title];
+			if (previousEnabled === undefined) {
+				try {
+					previousEnabled = await invoke<boolean>("is_mod_enabled", {
+						modName: mod.title,
+					});
+				} catch (error) {
+					console.error(
+						`Failed to read existing enabled state for ${mod.title}:`,
+						error,
+					);
+				}
+			}
+
+			if (previousEnabled !== undefined) {
+				desiredEnabledState = previousEnabled;
+			}
+		}
+
 		try {
 			if (!url.startsWith("http")) {
 				console.error("Invalid URL format:", url);
@@ -645,8 +694,10 @@ const { handleDependencyCheck, mod } = $props<{
 			installationStatus.update((s) => ({ ...s, [mod.title]: true }));
 			updateAvailableStore.update((s) => ({ ...s, [mod.title]: false }));
 
-			// Set as enabled by default
-			modEnabledStore.update((s) => ({ ...s, [mod.title]: true }));
+			modEnabledStore.update((s) => ({
+				...s,
+				[mod.title]: desiredEnabledState,
+			}));
 		} catch (error) {
 			console.error("Failed to install mod:", error);
 			throw error; // Rethrow to be handled by the caller

--- a/src/lib/opener.ts
+++ b/src/lib/opener.ts
@@ -14,7 +14,10 @@ export async function openExternal(url: string): Promise<void> {
     return;
   } catch (error) {
     // fall through to plugin/window fallback
-    console.warn("open_external_url failed, falling back to opener plugin", error);
+    console.warn(
+      "open_external_url failed, falling back to opener plugin",
+      error,
+    );
   }
 
   try {
@@ -26,6 +29,9 @@ export async function openExternal(url: string): Promise<void> {
       return;
     }
     console.error("Failed to open external URL", error);
-    addMessage("Failed to open link. Please check your browser configuration.", "error");
+    addMessage(
+      "Failed to open link. Please check your browser configuration.",
+      "error",
+    );
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to mod installation and management, particularly around preserving the enabled/disabled state of mods during reinstallation. It also refactors environment variable handling in tests for better reliability and readability. Additional changes support Flatpak packaging and documentation.

### Mod installation and enabled state preservation

* The mod installer now detects if a mod was previously disabled (via `.lovelyignore`) and restores its disabled state after reinstallation, ensuring user preferences are maintained. (`src-tauri/bmm-lib/src/installer.rs`, `src/components/viewblock/ModCard.svelte`, `src/components/viewblock/Mods.svelte`) [[1]](diffhunk://#diff-ad35c6d9bb1fe1f570bc5946f51607f8663ae271476f028de11012354234e737R98) [[2]](diffhunk://#diff-ad35c6d9bb1fe1f570bc5946f51607f8663ae271476f028de11012354234e737R112-R116) [[3]](diffhunk://#diff-ad35c6d9bb1fe1f570bc5946f51607f8663ae271476f028de11012354234e737R474-R501) [[4]](diffhunk://#diff-ad35c6d9bb1fe1f570bc5946f51607f8663ae271476f028de11012354234e737R642-R657) [[5]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4R186-R210) [[6]](diffhunk://#diff-ebd7523a8da4eaca4c5780ddc2cd40d1c02205ce441fc70cfb664a4fb5a0a3f4L229-R258) [[7]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR519-R542) [[8]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL589-R616) [[9]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebR649-R671) [[10]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL648-R700)

### Test environment improvements

* Refactored test code to use helper functions for setting and removing environment variables, improving code clarity and reducing repetition in test setup and teardown. (`src-tauri/bmm-lib/src/cache.rs`, `src-tauri/bmm-lib/src/finder.rs`, `src-tauri/src/commands/detection.rs`) [[1]](diffhunk://#diff-cb0c2a0f5eccd87c05828256c6732dedc0ee69317b868168c88b551f84235420R358-R388) [[2]](diffhunk://#diff-8db0488a1a7e2a3a57eb733ac637ebbf9d5f466724ac1f7a7ad368ba514ec17bR378-R397) [[3]](diffhunk://#diff-8db0488a1a7e2a3a57eb733ac637ebbf9d5f466724ac1f7a7ad368ba514ec17bL415-R429) [[4]](diffhunk://#diff-0398506030d89a9b9b315066c57b1ebcda0305052cadc95134452cc42ff1b09bR118-R137) [[5]](diffhunk://#diff-0398506030d89a9b9b315066c57b1ebcda0305052cadc95134452cc42ff1b09bL154-R168)

### Flatpak packaging and documentation

* Added `.flatpak-builder/**` to `.prettierignore` and updated the Flatpak section in `README.md` with clearer instructions. Minor cleanup in Flatpak packaging config. (`.prettierignore`, `README.md`, `packaging/flatpak/io.balatro.ModManager.json`) [[1]](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R23-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R32) [[3]](diffhunk://#diff-cfe00f62635e9a1f048ebf348da6a36b367a3ffbcab7f66b6783a74d87b0d0f5L38-R38)

### Minor code and logging improvements

* Improved logging and error handling in the external URL opener utility for better diagnostics. (`src/lib/opener.ts`) [[1]](diffhunk://#diff-be88f922d14a5613c15c892a6fa9eb1078436fd678ad0f9e47a2b33fe82c6d23L17-R20) [[2]](diffhunk://#diff-be88f922d14a5613c15c892a6fa9eb1078436fd678ad0f9e47a2b33fe82c6d23L29-R35)