### PR TITLE
fix: remove virtualization styles after simplifying mod/search lists

### DIFF
--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -84,25 +84,15 @@ import { openExternal } from "$lib/opener";
 	let paginationIdleTimer: number | null = null;
 	let hydrationTimer: number | null = null;
 	let hydrationPending = false;
-	let downloadsRefreshTimer: number | null = null;
-	let downloadsRefreshing = false;
+let downloadsRefreshTimer: number | null = null;
+let downloadsRefreshing = false;
 let isLinux = false;
 let modsScrollContainer: HTMLDivElement | null = $state(null);
 let scrollIdleTimer: number | null = null;
 let isUserScrolling = $state(false);
-const gridGap = 30;
-let virtualPaddingTop = $state(0);
-let virtualPaddingBottom = $state(0);
-let virtualCols = $state(1);
-let virtualRowHeight = $state(390);
-const virtualOverscanRows = 2;
 let renderLimitLocal = $state(60);
 const renderChunkLocal = 24;
 let localSentinel: HTMLDivElement | null = $state(null);
-let modsGridEl: HTMLDivElement | null = $state(null);
-let firstCardEl: HTMLElement | null = null;
-let scrollRaf: number | null = null;
-let resizeObs: ResizeObserver | null = null;
 
 	async function handleModUninstalled() {
 		// Refresh the local mods list
@@ -1615,11 +1605,6 @@ const { handleDependencyCheck, mod } = $props<{
 			isUserScrolling = false;
 			if (hydrationPending) scheduleHydration();
 		}, delay);
-		if (scrollRaf !== null) cancelAnimationFrame(scrollRaf);
-		scrollRaf = requestAnimationFrame(() => {
-			scrollRaf = null;
-			updateVirtualWindow();
-		});
 	}
 
 // Safely register global click handler with cleanup to avoid duplicates
@@ -1681,100 +1666,8 @@ onDestroy(() => {
 
 	let visiblePaginatedMods: Mod[] = $state([]);
 
-	function measureGrid() {
-		if (!modsGridEl) return;
-		const width = modsGridEl.clientWidth || 0;
-		const estimatedCardWidth = Math.max(
-			260,
-			firstCardEl?.getBoundingClientRect().width || 280,
-		);
-		const cols = Math.max(
-			1,
-			Math.floor((width + gridGap) / (estimatedCardWidth + gridGap)),
-		);
-		virtualCols = cols;
-		const measuredHeight = firstCardEl?.getBoundingClientRect().height;
-		if (measuredHeight && measuredHeight > 0) {
-			virtualRowHeight = Math.round(measuredHeight + gridGap);
-		}
-	}
-
 	function updateVirtualWindow() {
-		if ($currentCategory === "Installed Mods") {
-			visiblePaginatedMods = paginatedMods;
-			virtualPaddingTop = 0;
-			virtualPaddingBottom = 0;
-			return;
-		}
-
-		if (!modsScrollContainer) {
-			visiblePaginatedMods = paginatedMods;
-			virtualPaddingTop = 0;
-			virtualPaddingBottom = 0;
-			return;
-		}
-
-		measureGrid();
-
-		const total = paginatedMods.length;
-		if (total === 0) {
-			visiblePaginatedMods = [];
-			virtualPaddingTop = 0;
-			virtualPaddingBottom = 0;
-			return;
-		}
-
-		const rowHeight = Math.max(120, virtualRowHeight);
-		const viewportHeight = modsScrollContainer.clientHeight || 800;
-		const scrollTop = modsScrollContainer.scrollTop;
-		const totalRows = Math.max(1, Math.ceil(total / virtualCols));
-		const startRow = Math.max(
-			0,
-			Math.floor(scrollTop / rowHeight) - virtualOverscanRows,
-		);
-		const endRow = Math.min(
-			totalRows,
-			Math.ceil((scrollTop + viewportHeight) / rowHeight) + virtualOverscanRows,
-		);
-		const startIdx = startRow * virtualCols;
-		const endIdx = Math.min(total, endRow * virtualCols);
-		if (endIdx <= startIdx) {
-			visiblePaginatedMods = paginatedMods.slice(
-				0,
-				Math.min(total, virtualCols),
-			);
-		} else {
-			visiblePaginatedMods = paginatedMods.slice(startIdx, endIdx);
-		}
-		virtualPaddingTop = startRow * rowHeight;
-		virtualPaddingBottom = Math.max(
-			0,
-			totalRows * rowHeight - endRow * rowHeight,
-		);
-	}
-
-	function measureCell(node: HTMLElement, index: number) {
-		if (index === 0) {
-			firstCardEl = node;
-			measureGrid();
-			updateVirtualWindow();
-		}
-		return {
-			update(newIndex: number) {
-				if (newIndex === 0) {
-					firstCardEl = node;
-					measureGrid();
-					updateVirtualWindow();
-				} else if (firstCardEl === node) {
-					firstCardEl = null;
-				}
-			},
-			destroy() {
-				if (firstCardEl === node) {
-					firstCardEl = null;
-				}
-			},
-		};
+		visiblePaginatedMods = paginatedMods;
 	}
 
 // Whenever the visible page changes, try to quickly hydrate from cache and recalc window
@@ -1791,42 +1684,11 @@ $effect(() => {
     scheduleHydration();
 });
 
-onMount(() => {
-	if (typeof ResizeObserver !== "undefined") {
-		resizeObs = new ResizeObserver(() => {
-			measureGrid();
-			updateVirtualWindow();
-		});
-		if (modsScrollContainer) {
-			resizeObs.observe(modsScrollContainer);
-		}
-	}
-});
-
-$effect(() => {
-	if (!resizeObs || !modsScrollContainer) return;
-	resizeObs.disconnect();
-	resizeObs.observe(modsScrollContainer);
-});
-
-$effect(() => {
-	modsGridEl;
-	measureGrid();
-	updateVirtualWindow();
-});
-
 onDestroy(() => {
     if (visibleHydrateTimer !== null) {
         clearTimeout(visibleHydrateTimer);
         visibleHydrateTimer = null;
     }
-	if (resizeObs) {
-		try {
-			resizeObs.disconnect();
-		} catch (_) {
-			/* ignore */
-		}
-	}
 });
 
 	const maxVisiblePages = 5;
@@ -2212,17 +2074,11 @@ onDestroy(() => {
 								<div
 									class="mods-grid"
 									class:has-local-mods={localMods.length > 0}
-									bind:this={modsGridEl}
 								>
-									<div
-										class="virtual-spacer"
-										style={`height:${virtualPaddingTop}px`}
-										aria-hidden="true"
-									></div>
 									{#each visiblePaginatedMods.filter((m) =>
 										enabledMods.some((e) => e.title === m.title)
 									) as mod, index (mod.title)}
-										<div class="virtual-cell" use:measureCell={index}>
+										<div class="virtual-cell">
 											<ModCard
 												{mod}
 												deferImages={paginating}
@@ -2233,11 +2089,6 @@ onDestroy(() => {
 											/>
 										</div>
 									{/each}
-									<div
-										class="virtual-spacer"
-										style={`height:${virtualPaddingBottom}px`}
-										aria-hidden="true"
-									></div>
 								</div>
 							{/if}
 
@@ -2255,17 +2106,11 @@ onDestroy(() => {
 								<div
 									class="mods-grid"
 									class:has-local-mods={localMods.length > 0}
-									bind:this={modsGridEl}
 								>
-									<div
-										class="virtual-spacer"
-										style={`height:${virtualPaddingTop}px`}
-										aria-hidden="true"
-									></div>
 									{#each visiblePaginatedMods.filter((m) =>
 										disabledMods.some((e) => e.title === m.title)
 									) as mod, index (mod.title)}
-										<div class="virtual-cell" use:measureCell={index}>
+										<div class="virtual-cell">
 											<ModCard
 												{mod}
 												deferImages={paginating}
@@ -2276,24 +2121,14 @@ onDestroy(() => {
 											/>
 										</div>
 									{/each}
-									<div
-										class="virtual-spacer"
-										style={`height:${virtualPaddingBottom}px`}
-										aria-hidden="true"
-									></div>
 								</div>
 							{/if}
 
 							{#if enabledMods.length === 0 && disabledMods.length === 0}
 								<!-- Fallback: show installed catalog mods before enabled state resolves -->
-								<div class="mods-grid" bind:this={modsGridEl}>
-									<div
-										class="virtual-spacer"
-										style={`height:${virtualPaddingTop}px`}
-										aria-hidden="true"
-									></div>
+								<div class="mods-grid">
 									{#each visiblePaginatedMods as mod, index (mod.title)}
-										<div class="virtual-cell" use:measureCell={index}>
+										<div class="virtual-cell">
 											<ModCard
 												{mod}
 												deferImages={paginating}
@@ -2304,24 +2139,14 @@ onDestroy(() => {
 											/>
 										</div>
 									{/each}
-									<div
-										class="virtual-spacer"
-										style={`height:${virtualPaddingBottom}px`}
-										aria-hidden="true"
-									></div>
 								</div>
 							{/if}
 						{/if}
 					{:else}
 						<!-- Original non-InstalledMods categories -->
-						<div class="mods-grid" bind:this={modsGridEl}>
-							<div
-								class="virtual-spacer"
-								style={`height:${virtualPaddingTop}px`}
-								aria-hidden="true"
-							></div>
+						<div class="mods-grid">
 							{#each visiblePaginatedMods as mod, index (mod.title)}
-								<div class="virtual-cell" use:measureCell={index}>
+								<div class="virtual-cell">
 									<ModCard
 										{mod}
 										deferImages={paginating}
@@ -2331,11 +2156,6 @@ onDestroy(() => {
 									/>
 								</div>
 							{/each}
-							<div
-								class="virtual-spacer"
-								style={`height:${virtualPaddingBottom}px`}
-								aria-hidden="true"
-							></div>
 						</div>
 					{/if}
 				</div>
@@ -2521,12 +2341,6 @@ onDestroy(() => {
 	.render-sentinel {
 		width: 100%;
 		height: 1px;
-	}
-
-	.virtual-spacer {
-		grid-column: 1 / -1;
-		width: 100%;
-		pointer-events: none;
 	}
 
 	.virtual-cell {

--- a/src/components/viewblock/SearchView.svelte
+++ b/src/components/viewblock/SearchView.svelte
@@ -22,8 +22,6 @@ function debounce<T extends (...args: unknown[]) => void>(fn: T, wait: number) {
 import { addMessage } from "$lib/stores";
 import { fade } from "svelte/transition";
 import ModCard from "./ModCard.svelte";
-import { cardScale } from "../../stores/ui";
-import { tick } from "svelte";
 
 	let searchQuery = $state("");
 	let searchResults = $state<Mod[]>([]);
@@ -298,164 +296,13 @@ import { tick } from "svelte";
 		handleSearch();
 	}
 
-	const BASE_CARD_WIDTH = 300;
-	const BASE_CARD_HEIGHT = 330;
-	const GRID_GAP_FALLBACK = 16;
-	const OVERSCAN_ROWS = 1;
-
 	let scrollContainer: HTMLDivElement | null = $state(null);
-	let resultsWrapper: HTMLDivElement | null = $state(null);
-	let containerHeight = $state(0);
-	let containerWidth = $state(0);
-	let measuredCardHeight = $state(BASE_CARD_HEIGHT);
-	let measuredCardWidth = $state(BASE_CARD_WIDTH);
-	let gridGap = $state(GRID_GAP_FALLBACK);
-	let columnCount = $state(1);
-	let paddingTop = $state(0);
-	let paddingBottom = $state(0);
-	let visibleResults = $state<Mod[]>([]);
-	let totalRows = $state(0);
-	let hasMeasuredCard = $state(false);
-	let resizeObserver: ResizeObserver | null = null;
-	let rafId: number | null = null;
-	let measuring = false;
-
-	function scheduleVirtualUpdate() {
-		if (rafId !== null) {
-			cancelAnimationFrame(rafId);
-		}
-		rafId = requestAnimationFrame(() => {
-			rafId = null;
-			updateVirtualWindow();
-		});
-	}
-
-	function updateVirtualWindow() {
-		if (!scrollContainer) {
-			visibleResults = searchResults;
-			paddingTop = 0;
-			paddingBottom = 0;
-			totalRows = searchResults.length > 0 ? 1 : 0;
-			return;
-		}
-
-		const rowHeight = measuredCardHeight + gridGap;
-		const width =
-			containerWidth || scrollContainer.clientWidth || measuredCardWidth;
-		const effectiveCardWidth = measuredCardWidth + gridGap;
-		const cols = Math.max(
-			1,
-			Math.floor((width + gridGap) / Math.max(1, effectiveCardWidth)),
-		);
-		columnCount = cols;
-
-		if (searchResults.length === 0 || rowHeight <= 0) {
-			visibleResults = [];
-			paddingTop = 0;
-			paddingBottom = 0;
-			totalRows = 0;
-			return;
-		}
-
-		const totalRowCount = Math.max(
-			1,
-			Math.ceil(searchResults.length / cols),
-		);
-		totalRows = totalRowCount;
-		const scrollTop = scrollContainer.scrollTop;
-		const viewportHeight =
-			containerHeight || scrollContainer.clientHeight || 0;
-		const startRow = Math.max(
-			0,
-			Math.floor(scrollTop / rowHeight) - OVERSCAN_ROWS,
-		);
-		const endRow = Math.min(
-			totalRowCount - 1,
-			Math.ceil((scrollTop + viewportHeight) / rowHeight) +
-				OVERSCAN_ROWS,
-		);
-
-		const startIndex = startRow * cols;
-		const endIndex = Math.min(searchResults.length, (endRow + 1) * cols);
-		visibleResults = searchResults.slice(startIndex, endIndex);
-
-		paddingTop = startRow * rowHeight;
-		const renderedRows = Math.ceil(visibleResults.length / cols);
-		const consumed = paddingTop + renderedRows * rowHeight;
-		const totalHeight = totalRowCount * rowHeight;
-		paddingBottom = Math.max(totalHeight - consumed, 0);
-	}
-
-	async function measureCardSize() {
-		if (measuring) return;
-		measuring = true;
-		await tick();
-		const wrapper = resultsWrapper;
-		if (wrapper) {
-			const sample = wrapper.querySelector(".mod-card");
-			if (sample instanceof HTMLElement) {
-				const rect = sample.getBoundingClientRect();
-				measuredCardHeight = rect.height;
-				measuredCardWidth = rect.width;
-				hasMeasuredCard = true;
-			}
-			const style = getComputedStyle(wrapper);
-			const nextGap =
-				parseFloat(style.rowGap || style.gap || "") ||
-				GRID_GAP_FALLBACK;
-			gridGap = Number.isFinite(nextGap) ? nextGap : GRID_GAP_FALLBACK;
-		}
-		measuring = false;
-		scheduleVirtualUpdate();
-	}
-
-	function handleScroll() {
-		if (!scrollContainer) return;
-		scheduleVirtualUpdate();
-	}
-
-	onMount(() => {
-		const updateSizes = () => {
-			if (!scrollContainer) return;
-			containerHeight = scrollContainer.clientHeight;
-			containerWidth = scrollContainer.clientWidth;
-			scheduleVirtualUpdate();
-		};
-
-		updateSizes();
-		resizeObserver = new ResizeObserver(updateSizes);
-		if (scrollContainer) resizeObserver.observe(scrollContainer);
-
-		return () => {
-			if (resizeObserver) resizeObserver.disconnect();
-			if (rafId !== null) cancelAnimationFrame(rafId);
-		};
-	});
 
 	$effect(() => {
 		searchResults;
 		if (scrollContainer) {
 			scrollContainer.scrollTop = 0;
 		}
-		visibleResults =
-			searchResults.length > 0 ? searchResults.slice(0, 1) : [];
-		hasMeasuredCard = false;
-		scheduleVirtualUpdate();
-	});
-
-	$effect(() => {
-		if (!hasMeasuredCard && visibleResults.length > 0) {
-			measureCardSize();
-		}
-	});
-
-	$effect(() => {
-		// Recompute when card scale changes (affects measured size)
-		$cardScale;
-		hasMeasuredCard = false;
-		measuredCardHeight = BASE_CARD_HEIGHT * $cardScale;
-		measuredCardWidth = BASE_CARD_WIDTH * $cardScale;
-		scheduleVirtualUpdate();
 	});
 </script>
 
@@ -484,7 +331,6 @@ import { tick } from "svelte";
 	<div
 		class="results-scroll-container default-scrollbar"
 		bind:this={scrollContainer}
-		onscroll={handleScroll}
 	>
 		<div class="results-container">
 			{#if isSearching}
@@ -499,16 +345,8 @@ import { tick } from "svelte";
 				<div
 					transition:fade={{ duration: 100 }}
 					class="results-wrapper"
-					bind:this={resultsWrapper}
 				>
-					{#if paddingTop > 0}
-						<div
-							class="virtual-spacer"
-							style={`height:${paddingTop}px`}
-							aria-hidden="true"
-						></div>
-					{/if}
-					{#each visibleResults as mod (mod.title)}
+					{#each searchResults as mod (mod.title)}
 						<ModCard
 							{mod}
 							oninstallclick={installMod}
@@ -516,13 +354,6 @@ import { tick } from "svelte";
 							onmodclick={handleModClick}
 						/>
 					{/each}
-					{#if paddingBottom > 0}
-						<div
-							class="virtual-spacer"
-							style={`height:${paddingBottom}px`}
-							aria-hidden="true"
-						></div>
-					{/if}
 				</div>
 			{/if}
 		</div>
@@ -642,11 +473,6 @@ import { tick } from "svelte";
 		transform: translateZ(0);
 		will-change: scroll-position;
 		overscroll-behavior: contain;
-	}
-
-	.virtual-spacer {
-		grid-column: 1 / -1;
-		pointer-events: none;
 	}
 
 	@media (max-width: 1160px) {


### PR DESCRIPTION
This pull request removes the custom virtual scrolling/grid logic from both the `Mods.svelte` and `SearchView.svelte` components, simplifying the codebase and UI rendering. The changes eliminate dynamic measurement, overscan, and spacer elements, opting instead for straightforward rendering of filtered mod lists. This should make the code easier to maintain and debug, at the cost of potentially reduced performance with very large lists.

**Major changes:**

*Removal of virtual scrolling/grid logic in Mods view:*
- Deleted all variables, functions, and effects related to calculating grid columns, row heights, overscan, and virtual padding/spacers in `src/components/viewblock/Mods.svelte`. This includes the removal of `measureGrid`, `updateVirtualWindow`, `measureCell`, and related resize/scroll handlers. [[1]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL93-L105) [[2]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL1618-L1622) [[3]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL1684-L1777) [[4]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL1794-L1829)
- Removed the use of virtual spacer divs and the `measureCell` action from the template, so all filtered mods are rendered directly without virtualization. [[1]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL2215-R2081) [[2]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL2236-L2240) [[3]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL2258-R2113) [[4]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL2279-R2131) [[5]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL2307-R2149) [[6]](diffhunk://#diff-2d97a806ef22bd2878b6e4b903efc2b5eaaa0fb2c8eb4c41a9eb5c2f80db19ebL2334-L2338)
- Deleted associated virtual grid CSS for `.virtual-spacer`.

*Removal of virtual scrolling/grid logic in Search view:*
- Removed all state and logic related to measuring card sizes, calculating grid columns, overscan, and virtual padding/spacers in `src/components/viewblock/SearchView.svelte`. This includes the removal of `updateVirtualWindow`, `measureCardSize`, resize observers, and scroll handlers.
- Updated the template to render all `searchResults` directly, removing the use of `visibleResults`, spacer divs, and related bindings/actions. [[1]](diffhunk://#diff-ff210d0d83b81e7c8c79b6c502a9f8cc9be8ddb21b835cd1ffaebeaf8884fbd5L487) [[2]](diffhunk://#diff-ff210d0d83b81e7c8c79b6c502a9f8cc9be8ddb21b835cd1ffaebeaf8884fbd5L502-L525)
- Deleted associated virtual grid CSS for `.virtual-spacer`.

*General code cleanup:*
- Removed unused imports and variables that were only needed for the virtual grid logic.

These changes significantly simplify the rendering logic for mod lists and search results, making the components easier to understand and maintain. However, be aware that rendering performance may degrade if the lists become very large, since all items are now rendered at once.