### PR TITLE
fix: manually installed mods not being displayed

### DIFF
--- a/src/components/LaunchButton.svelte
+++ b/src/components/LaunchButton.svelte
@@ -74,11 +74,12 @@ async function doLaunch() {
   let launched = false;
   try {
     launched = await doLaunch();
-  } finally {
-    if (!launched) {
-      isLaunching = false;
-      return;
-    }
+  } catch (_) {
+    launched = false;
+  }
+  if (!launched) {
+    isLaunching = false;
+    return;
   }
 
   if (launchCheckTimer) clearInterval(launchCheckTimer);

--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -335,12 +335,31 @@ const { handleDependencyCheck, mod } = $props<{
 		);
 
 		// Filter local mods - explicitly check for boolean values
-		enabledLocalMods = localMods.filter(
-			(mod) => $modEnabledStore[mod.name] === true,
-		);
-		disabledLocalMods = localMods.filter(
-			(mod) => $modEnabledStore[mod.name] === false,
-		);
+		const enabled: LocalMod[] = [];
+		const disabled: LocalMod[] = [];
+		for (const mod of localMods) {
+			const direct = $modEnabledStore[mod.name];
+			if (direct === true) {
+				enabled.push(mod);
+				continue;
+			}
+			if (direct === false) {
+				disabled.push(mod);
+				continue;
+			}
+			const folderName = mod.path.split(/[\\/]/).pop();
+			const byPath =
+				folderName && folderName in $modEnabledStore
+					? $modEnabledStore[folderName]
+					: undefined;
+			if (byPath === false) {
+				disabled.push(mod);
+			} else {
+				enabled.push(mod);
+			}
+		}
+		enabledLocalMods = enabled;
+		disabledLocalMods = disabled;
 	}
 
 	// Update the lists whenever the stores change


### PR DESCRIPTION
This pull request improves error handling during the launch process and refines the logic for determining enabled and disabled local mods. The main changes focus on making the launch process more robust and ensuring that mod status is checked more accurately, including fallback checks by folder name.

**Error handling improvements:**

* Updated the `doLaunch` function in `LaunchButton.svelte` to explicitly catch errors and set `launched` to `false` if an exception occurs, instead of using a `finally` block. This prevents unintended state changes when launch fails.

**Mod status determination improvements:**

* Refactored the logic in `Mods.svelte` for filtering enabled and disabled local mods: now, if a mod's enabled status is not directly found, the code checks by the mod's folder name as a fallback. This ensures mods are categorized correctly even if their names differ from their folder names.