### PR TITLE
fix: improve Linux Steam detection and Proton mods sync

### DIFF
--- a/src-tauri/bmm-lib/src/cache.rs
+++ b/src-tauri/bmm-lib/src/cache.rs
@@ -400,15 +400,14 @@ mod tests {
     }
 
     fn with_temp_cache<T>(test: impl FnOnce(PathBuf) -> T) -> T {
+        let _lock = crate::ENV_LOCK.lock().unwrap();
         let temp_dir = tempdir().unwrap();
         let original_cache = std::env::var_os("XDG_CACHE_HOME");
         let original_home = std::env::var_os("HOME");
 
         set_var("XDG_CACHE_HOME", temp_dir.path());
-        // On macOS, dirs::cache_dir uses ~/Library/Caches, so set HOME to our temp dir
-        if cfg!(target_os = "macos") {
-            set_var("HOME", temp_dir.path());
-        }
+        // Ensure HOME points at temp so flatpak cache fallbacks don't hit real user data.
+        set_var("HOME", temp_dir.path());
         let result = test(temp_dir.path().to_path_buf());
 
         // restore env

--- a/src-tauri/bmm-lib/src/finder.rs
+++ b/src-tauri/bmm-lib/src/finder.rs
@@ -3,6 +3,8 @@ use log::{debug, error};
 #[cfg(target_os = "linux")]
 use regex::Regex;
 use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::collections::VecDeque;
 #[cfg(target_os = "windows")]
 use std::fs::File;
 #[cfg(target_os = "windows")]
@@ -178,6 +180,62 @@ fn parse_libraryfolders(library_path: &Path) -> Vec<PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
+fn scan_for_steamapps_dirs(base: &Path, max_depth: usize, max_dirs: usize) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut queue: VecDeque<(PathBuf, usize)> = VecDeque::new();
+    let mut visited: usize = 0;
+
+    if !base.exists() {
+        return found;
+    }
+
+    queue.push_back((base.to_path_buf(), 0));
+
+    while let Some((dir, depth)) = queue.pop_front() {
+        if visited >= max_dirs {
+            break;
+        }
+        visited += 1;
+
+        let dir_name = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        if dir_name == "steamapps" {
+            found.push(dir);
+            continue;
+        }
+
+        if depth >= max_depth {
+            continue;
+        }
+
+        if dir_name == "node_modules"
+            || dir_name == ".git"
+            || dir_name == "cache"
+            || dir_name == ".cache"
+            || dir_name == "trash"
+            || dir_name == ".trash"
+        {
+            continue;
+        }
+
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    queue.push_back((path, depth + 1));
+                }
+            }
+        }
+    }
+
+    found
+}
+
+#[cfg(target_os = "linux")]
 pub fn get_balatro_paths() -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = vec![];
 
@@ -204,15 +262,68 @@ pub fn get_balatro_paths() -> Vec<PathBuf> {
         Some(home) => {
             add_root(home.join(".local/share/Steam"));
             add_root(home.join(".steam/steam"));
+            add_root(home.join(".steam/root"));
+            add_root(home.join(".steam/debian-installation"));
             add_root(home.join(".var/app/com.valvesoftware.Steam/data/Steam"));
+            // Some Flatpak Steam installs use the per-app .local/share path.
+            add_root(home.join(".var/app/com.valvesoftware.Steam/.local/share/Steam"));
+            add_root(home.join(".var/app/com.valvesoftware.Steam/.steam/steam"));
+            add_root(home.join(".var/app/com.valvesoftware.Steam/.steam/root"));
             // Snap installs keep the real Steam data under this prefix.
             add_root(home.join("snap/steam/common/.local/share/Steam"));
         }
         None => error!("Impossible to get your home dir!"),
     }
 
+    if let Ok(xdg_data_home) = std::env::var("XDG_DATA_HOME") {
+        let xdg = PathBuf::from(xdg_data_home);
+        add_root(xdg.join("Steam"));
+        add_root(xdg.join("steam"));
+    }
+
+    add_root(PathBuf::from("/opt/steam"));
+    add_root(PathBuf::from("/opt/Steam"));
+    add_root(PathBuf::from("/usr/lib/steam"));
+    add_root(PathBuf::from("/usr/local/steam"));
+    add_root(PathBuf::from("/var/lib/steam"));
+
+    let mut steamapps_dirs: Vec<PathBuf> = Vec::new();
+    let mut seen_steamapps: HashSet<String> = HashSet::new();
+    let mut add_steamapps = |path: PathBuf| {
+        let key = path.to_string_lossy().to_string().to_lowercase();
+        if seen_steamapps.insert(key) {
+            steamapps_dirs.push(path);
+        }
+    };
+
     for root in steam_roots {
-        let steamapps = root.join("steamapps");
+        add_steamapps(root.join("steamapps"));
+    }
+
+    if let Some(home) = home::home_dir() {
+        add_steamapps(home.join(".steam/steamapps"));
+        let bases = vec![
+            home.join(".local/share"),
+            home.join(".steam"),
+            home.join(".var/app"),
+            home.join("snap"),
+            home.clone(),
+        ];
+        for base in bases {
+            for steamapps in scan_for_steamapps_dirs(&base, 5, 2000) {
+                add_steamapps(steamapps);
+            }
+        }
+    }
+
+    if let Ok(user) = std::env::var("USER") {
+        let media_base = PathBuf::from("/run/media").join(user);
+        for steamapps in scan_for_steamapps_dirs(&media_base, 4, 1500) {
+            add_steamapps(steamapps);
+        }
+    }
+
+    for steamapps in steamapps_dirs {
         paths.push(steamapps.join("common/Balatro"));
 
         let libraryfolders = steamapps.join("libraryfolders.vdf");
@@ -387,14 +498,14 @@ mod tests {
 
     #[test]
     fn test_get_installed_mods_filters_lovely_dirs() {
+        let _lock = crate::ENV_LOCK.lock().unwrap();
         let tmp = tempdir().unwrap();
         // Redirect config dir to temp using XDG_CONFIG_HOME and HOME (for macOS)
         let original_cfg = std::env::var_os("XDG_CONFIG_HOME");
         let original_home = std::env::var_os("HOME");
         set_var("XDG_CONFIG_HOME", tmp.path());
-        if cfg!(target_os = "macos") {
-            set_var("HOME", tmp.path());
-        }
+        // Ensure HOME points at temp so path resolution doesn't touch real user dirs.
+        set_var("HOME", tmp.path());
 
         let mods_root = dirs::config_dir().unwrap().join("Balatro").join("Mods");
         std::fs::create_dir_all(&mods_root).unwrap();

--- a/src-tauri/bmm-lib/src/lib.rs
+++ b/src-tauri/bmm-lib/src/lib.rs
@@ -12,6 +12,11 @@ pub mod mod_collections;
 pub mod smods_installer;
 
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(test)]
+pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// Resolve the mods directory on the host (config dir).
 pub fn mods_dir() -> PathBuf {

--- a/src-tauri/bmm-lib/src/local_mod_detection.rs
+++ b/src-tauri/bmm-lib/src/local_mod_detection.rs
@@ -104,6 +104,9 @@ pub fn mod_dir_candidates() -> Result<Vec<PathBuf>, String> {
                 compat_candidates.push(home.join(
                     ".local/share/Steam/steamapps/compatdata/2379780/pfx/drive_c/users/steamuser/AppData/Roaming/Balatro/Mods",
                 ));
+                compat_candidates.push(home.join(
+                    ".var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/compatdata/2379780/pfx/drive_c/users/steamuser/AppData/Roaming/Balatro/Mods",
+                ));
             }
             candidates.extend(compat_candidates);
         }

--- a/src-tauri/src/commands/install.rs
+++ b/src-tauri/src/commands/install.rs
@@ -342,9 +342,8 @@ fn find_steamapps_root(game_path: &Path) -> Option<PathBuf> {
 
 #[cfg(target_os = "linux")]
 fn ensure_proton_mod_dir_link(game_path: &Path) -> Result<(), String> {
-    let host_mods = dirs::config_dir()
-        .map(|d| d.join("Balatro").join("Mods"))
-        .ok_or_else(|| "Could not resolve config directory".to_string())?;
+    let host_mods = bmm_lib::local_mod_detection::resolve_mods_dir_path()
+        .map_err(|e| format!("Could not resolve mods directory: {e}"))?;
 
     let steamapps_dir = find_steamapps_root(game_path).or_else(|| {
         dirs::home_dir()
@@ -357,6 +356,10 @@ fn ensure_proton_mod_dir_link(game_path: &Path) -> Result<(), String> {
 
     let compat_mods = steamapps_dir
         .join("compatdata/2379780/pfx/drive_c/users/steamuser/AppData/Roaming/Balatro/Mods");
+
+    if compat_mods == host_mods {
+        return Ok(());
+    }
 
     if let Some(parent) = compat_mods.parent()
         && let Err(e) = fs::create_dir_all(parent)
@@ -376,6 +379,7 @@ fn ensure_proton_mod_dir_link(game_path: &Path) -> Result<(), String> {
             "Proton Mods path already exists and is not a symlink: {}",
             compat_mods.display()
         );
+        sync_proton_mods(&host_mods, &compat_mods)?;
         return Ok(());
     }
 
@@ -399,6 +403,61 @@ fn ensure_proton_mod_dir_link(game_path: &Path) -> Result<(), String> {
         compat_mods.display(),
         host_mods.display()
     );
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn sync_proton_mods(host_mods: &Path, compat_mods: &Path) -> Result<(), String> {
+    if !host_mods.exists() {
+        if let Err(e) = fs::create_dir_all(host_mods) {
+            warn!(
+                "Failed to create host mods dir {}: {}",
+                host_mods.display(),
+                e
+            );
+        }
+        return Ok(());
+    }
+
+    if !compat_mods.exists() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(host_mods).map_err(|e| {
+        format!(
+            "Failed to read host mods dir {}: {}",
+            host_mods.display(),
+            e
+        )
+    })?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = match path.file_name() {
+            Some(n) => n,
+            None => continue,
+        };
+        let dest = compat_mods.join(name);
+        if dest.exists() {
+            continue;
+        }
+        if let Err(e) = symlink(&path, &dest) {
+            warn!(
+                "Failed to link Proton mod {} -> {}: {}",
+                dest.display(),
+                path.display(),
+                e
+            );
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This pull request makes several improvements to Linux Steam and Proton mod directory detection and handling, as well as test reliability. The main changes include expanding the search for Steam library and mod directories on Linux, adding a robust scanning function for `steamapps` directories, improving symlink and directory handling for Proton mods, and making test environment setup safer and more isolated.

**Linux Steam/Proton directory detection and scanning:**
- Expanded the set of possible Steam root and mod directories on Linux by adding more candidate paths, including Flatpak, Snap, and system-wide locations, and improved detection logic for Proton mod directories. [[1]](diffhunk://#diff-8db0488a1a7e2a3a57eb733ac637ebbf9d5f466724ac1f7a7ad368ba514ec17bR265-R326) [[2]](diffhunk://#diff-8e04067e0555f1fa48b15f0865a8d1ea1cd1cdfed0f20891e39a77376d2901d4R107-R109)
- Introduced a new `scan_for_steamapps_dirs` function that recursively scans common base directories for `steamapps` folders, while skipping irrelevant or problematic directories, to robustly find all possible Steam library locations.

**Proton mod directory handling:**
- Improved the `ensure_proton_mod_dir_link` logic to use a new `resolve_mods_dir_path` function for determining the host mods directory, and added a check to skip linking if the Proton and host mod directories are the same. [[1]](diffhunk://#diff-ed02d02643aafa7cb7c4558e03da889e6e81c9a70a5d9ab91df4c061d200f2d5L345-R346) [[2]](diffhunk://#diff-ed02d02643aafa7cb7c4558e03da889e6e81c9a70a5d9ab91df4c061d200f2d5R360-R363)
- Added a `sync_proton_mods` function to create symlinks for each mod from the host mods directory to the Proton mods directory if the latter exists but is not a symlink, ensuring mods are accessible in Proton environments. [[1]](diffhunk://#diff-ed02d02643aafa7cb7c4558e03da889e6e81c9a70a5d9ab91df4c061d200f2d5R382) [[2]](diffhunk://#diff-ed02d02643aafa7cb7c4558e03da889e6e81c9a70a5d9ab91df4c061d200f2d5R409-R463)

**Test reliability improvements:**
- Introduced a global `ENV_LOCK` mutex for tests to prevent environment variable conflicts and ensure that temporary directories are used safely and consistently during tests. [[1]](diffhunk://#diff-067109e4363b2f574cf36adf113e1e62154cacf37d56630ba4de63ee1d531822R15-R19) [[2]](diffhunk://#diff-cb0c2a0f5eccd87c05828256c6732dedc0ee69317b868168c88b551f84235420R403-L411) [[3]](diffhunk://#diff-8db0488a1a7e2a3a57eb733ac637ebbf9d5f466724ac1f7a7ad368ba514ec17bR501-L397)

**Dependency and import updates:**
- Added `VecDeque` import for Linux builds to support the new scanning function.