### PR TITLE
chore: attach linux appimage/deb/rpm bundles to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
           # Upload original non-Windows artifacts AND the newly signed Windows executable
           files: |
             artifacts/**/*.dmg
+            artifacts/**/*.AppImage
+            artifacts/**/*.deb
+            artifacts/**/*.rpm
             signed-artifact/**/*.exe
             signed-artifact/**/*.msi
             artifacts/**/*.flatpak


### PR DESCRIPTION
closes https://github.com/skyline69/balatro-mod-manager/issues/333