### PR TITLE
fix(linux): correct LOVE mod directory symlink paths

### DIFF
--- a/src-tauri/src/commands/install.rs
+++ b/src-tauri/src/commands/install.rs
@@ -339,9 +339,11 @@ fn ensure_native_mod_dir_link() -> Result<(), String> {
     }
 
     // Link both data and config locations that LOVE may use
-    let love_mods_data = home_dir.join(".local/share/love/Mods");
+    // LOVE uses game-specific subdirectories based on the identity in conf.lua
+    // For Balatro, this is "Balatro", so mods should be in ~/.local/share/love/Balatro/Mods
+    let love_mods_data = home_dir.join(".local/share/love/Balatro/Mods");
     let _ = link_mods(love_mods_data);
-    let love_mods_config = host_config.join("love/Mods");
+    let love_mods_config = host_config.join("love/Balatro/Mods");
     let _ = link_mods(love_mods_config);
 
     Ok(())


### PR DESCRIPTION
Fixes #341

Fix symlinks for native LOVE mod loading on Linux to use the correct game-specific subdirectory structure. LOVE2D uses identity-based paths (~/.local/share/love/<IDENTITY>/), not generic paths.

Changes:
- Update ensure_native_mod_dir_link() to create symlinks at:
  - ~/.local/share/love/Balatro/Mods (was: ~/.local/share/love/Mods)
  - ~/.config/Balatro/love/Balatro/Mods (was: ~/.config/Balatro/love/Mods)

This fixes mods appearing as "installed" and "ON" in BMM but not loading in-game when using native LOVE (non-Steam/Proton) on Linux. The incorrect symlink paths were never checked by LOVE, which looks for game data in identity-specific subdirectories based on conf.lua.

Proton/Steam installations are unaffected (use different code path).