### PR TITLE
353 backup support

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,8 +143,8 @@ tasks:
       - cmd: bun run check
       - cmd: cd ./src-tauri && cargo fmt --all --check
       - cmd: cd ./src-tauri && cargo clippy -- -D warnings
-      - cmd: cd ./src-tauri && cargo test -q
-      - cmd: cd ./src-tauri/bmm-lib && cargo test -q
+      - cmd: cd ./src-tauri && cargo test -q -- --test-threads=1
+      - cmd: cd ./src-tauri/bmm-lib && cargo test -q -- --test-threads=1
   fmt:
     desc: Format Rust and frontend code
     cmds:
@@ -170,8 +170,8 @@ tasks:
   test:
     desc: Run Rust tests for both crates
     cmds:
-      - cmd: cd ./src-tauri && cargo test -q
-      - cmd: cd ./src-tauri/bmm-lib && cargo test -q
+      - cmd: cd ./src-tauri && cargo test -q -- --test-threads=1
+      - cmd: cd ./src-tauri/bmm-lib && cargo test -q -- --test-threads=1
   clean:
     desc: Clean build artifacts
     cmds:

--- a/src-tauri/bmm-lib/Cargo.toml
+++ b/src-tauri/bmm-lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow = "1.0.100"
 bincode = { version = "2.0", features = ["serde"] }
 bytes = "1.11.0"
-chrono = "0.4.43"
+chrono = { version = "0.4.43", features = ["serde"] }
 dirs = "6.0.0"
 discord-rich-presence = "1.0.0"
 env_logger = "0.11.8"

--- a/src-tauri/bmm-lib/src/backup.rs
+++ b/src-tauri/bmm-lib/src/backup.rs
@@ -1,0 +1,776 @@
+//! Backup and restore functionality for mod snapshots.
+//!
+//! This module provides automatic and manual backup capabilities for the Mods folder,
+//! allowing users to restore to previous states after updates, uninstalls, or other changes.
+
+use crate::database::{Database, InstalledMod};
+use crate::errors::AppError;
+use chrono::{DateTime, Utc};
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use tar::{Archive, Builder};
+
+/// Maximum number of automatic backups to retain.
+const MAX_AUTO_BACKUPS: usize = 5;
+
+/// Minimum interval between auto-backups in seconds (debounce).
+const AUTO_BACKUP_DEBOUNCE_SECS: i64 = 60;
+
+/// The trigger that caused a backup to be created.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackupTrigger {
+    /// Backup created before updating a mod.
+    AutoUpdate,
+    /// Backup created before uninstalling a mod.
+    AutoUninstall,
+    /// Backup created before bulk enable/disable operations.
+    AutoBulk,
+    /// Backup created manually by the user.
+    Manual,
+}
+
+impl BackupTrigger {
+    /// Returns true if this is an automatic backup trigger.
+    pub fn is_auto(&self) -> bool {
+        matches!(
+            self,
+            BackupTrigger::AutoUpdate | BackupTrigger::AutoUninstall | BackupTrigger::AutoBulk
+        )
+    }
+
+    /// Returns a human-readable description of the trigger.
+    pub fn description(&self) -> &'static str {
+        match self {
+            BackupTrigger::AutoUpdate => "Before updating mod",
+            BackupTrigger::AutoUninstall => "Before uninstalling mod",
+            BackupTrigger::AutoBulk => "Before bulk operation",
+            BackupTrigger::Manual => "Manual backup",
+        }
+    }
+}
+
+/// Metadata about a backup snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupMetadata {
+    /// Unique identifier for the backup.
+    pub id: String,
+    /// When the backup was created.
+    pub created_at: DateTime<Utc>,
+    /// What triggered the backup creation.
+    pub trigger: BackupTrigger,
+    /// User-provided name (for manual backups).
+    pub name: Option<String>,
+    /// Number of mods in the snapshot.
+    pub mod_count: usize,
+    /// Total size of the backup in bytes.
+    pub size_bytes: u64,
+    /// Lovely version at the time of backup.
+    pub lovely_version: Option<String>,
+}
+
+/// Database snapshot containing installed mod records.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DatabaseSnapshot {
+    /// List of installed mods at backup time.
+    installed_mods: Vec<ModRecord>,
+    /// List of enabled states (paths with .lovelyignore files).
+    disabled_mods: Vec<String>,
+}
+
+/// A mod record for the database snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ModRecord {
+    name: String,
+    path: String,
+    dependencies: Vec<String>,
+    current_version: Option<String>,
+}
+
+impl From<InstalledMod> for ModRecord {
+    fn from(m: InstalledMod) -> Self {
+        ModRecord {
+            name: m.name,
+            path: m.path,
+            dependencies: m.dependencies,
+            current_version: m.current_version,
+        }
+    }
+}
+
+/// Get the backups directory path.
+pub fn get_backups_dir() -> Result<PathBuf, AppError> {
+    let config_dir = dirs::config_dir()
+        .ok_or_else(|| AppError::DirNotFound(PathBuf::from("config directory")))?;
+    Ok(config_dir.join("Balatro").join("backups"))
+}
+
+/// Create a backup of the current mods folder and database state.
+///
+/// # Arguments
+/// * `trigger` - What triggered this backup
+/// * `name` - Optional user-provided name (for manual backups)
+/// * `context` - Optional context info (e.g., mod name being updated)
+///
+/// # Returns
+/// Metadata about the created backup, or an error.
+pub async fn create_backup(
+    trigger: BackupTrigger,
+    name: Option<String>,
+    context: Option<String>,
+) -> Result<BackupMetadata, AppError> {
+    let mods_dir = crate::mods_dir();
+    let backups_dir = get_backups_dir()?;
+
+    // Check if we should debounce auto-backups
+    if trigger.is_auto()
+        && let Ok(backups) = list_backups()
+        && let Some(latest) = backups.first()
+    {
+        let elapsed = Utc::now()
+            .signed_duration_since(latest.created_at)
+            .num_seconds();
+        if elapsed < AUTO_BACKUP_DEBOUNCE_SECS && latest.trigger.is_auto() {
+            log::debug!(
+                "Skipping auto-backup: last backup was {}s ago (debounce: {}s)",
+                elapsed,
+                AUTO_BACKUP_DEBOUNCE_SECS
+            );
+            return Ok(latest.clone());
+        }
+    }
+
+    // Create backups directory if it doesn't exist
+    fs::create_dir_all(&backups_dir).map_err(|e| AppError::DirCreate {
+        path: backups_dir.clone(),
+        source: e.to_string(),
+    })?;
+
+    // Generate backup ID and directory name
+    let now = Utc::now();
+    let trigger_str = match trigger {
+        BackupTrigger::AutoUpdate => "auto_update",
+        BackupTrigger::AutoUninstall => "auto_uninstall",
+        BackupTrigger::AutoBulk => "auto_bulk",
+        BackupTrigger::Manual => "manual",
+    };
+
+    let id = format!("{}_{}", now.format("%Y%m%d_%H%M%S"), trigger_str);
+    let backup_dir = backups_dir.join(&id);
+
+    fs::create_dir_all(&backup_dir).map_err(|e| AppError::DirCreate {
+        path: backup_dir.clone(),
+        source: e.to_string(),
+    })?;
+
+    // Get database state
+    let db = Database::new()?;
+    let installed_mods = db.get_installed_mods()?;
+    let mod_count = installed_mods.len();
+    let lovely_version = db.get_lovely_version().ok().flatten();
+
+    // Find disabled mods (those with .lovelyignore files)
+    let disabled_mods = find_disabled_mods(&mods_dir)?;
+
+    // Create database snapshot
+    let db_snapshot = DatabaseSnapshot {
+        installed_mods: installed_mods.into_iter().map(ModRecord::from).collect(),
+        disabled_mods,
+    };
+
+    let db_snapshot_path = backup_dir.join("database.json");
+    let db_json = serde_json::to_string_pretty(&db_snapshot)?;
+    fs::write(&db_snapshot_path, &db_json)
+        .map_err(|e| AppError::InvalidState(format!("Failed to write database snapshot: {}", e)))?;
+
+    // Create compressed tar archive of mods folder
+    let archive_path = backup_dir.join("mods.tar.gz");
+    create_mods_archive(&mods_dir, &archive_path)?;
+
+    // Calculate total size
+    let archive_size = fs::metadata(&archive_path).map(|m| m.len()).unwrap_or(0);
+    let db_size = fs::metadata(&db_snapshot_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let size_bytes = archive_size + db_size;
+
+    // Build display name
+    let display_name = match (&name, &context) {
+        (Some(n), _) => Some(n.clone()),
+        (None, Some(ctx)) => Some(format!("{} {}", trigger.description(), ctx)),
+        (None, None) => None,
+    };
+
+    // Create metadata
+    let metadata = BackupMetadata {
+        id: id.clone(),
+        created_at: now,
+        trigger,
+        name: display_name,
+        mod_count,
+        size_bytes,
+        lovely_version,
+    };
+
+    // Write metadata file
+    let metadata_path = backup_dir.join("metadata.json");
+    let metadata_json = serde_json::to_string_pretty(&metadata)?;
+    fs::write(&metadata_path, &metadata_json)
+        .map_err(|e| AppError::InvalidState(format!("Failed to write backup metadata: {}", e)))?;
+
+    // Enforce retention policy for auto-backups
+    enforce_retention()?;
+
+    log::info!(
+        "Created backup '{}': {} mods, {} bytes",
+        id,
+        mod_count,
+        size_bytes
+    );
+
+    Ok(metadata)
+}
+
+/// Find mods that have .lovelyignore files (disabled mods).
+fn find_disabled_mods(mods_dir: &Path) -> Result<Vec<String>, AppError> {
+    let mut disabled = Vec::new();
+
+    if !mods_dir.exists() {
+        return Ok(disabled);
+    }
+
+    let entries = fs::read_dir(mods_dir)
+        .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let ignore_file = path.join(".lovelyignore");
+            if ignore_file.exists()
+                && let Some(name) = path.file_name().and_then(|n| n.to_str())
+            {
+                disabled.push(name.to_string());
+            }
+        }
+    }
+
+    Ok(disabled)
+}
+
+/// Create a compressed tar archive of the mods folder.
+fn create_mods_archive(mods_dir: &Path, archive_path: &Path) -> Result<(), AppError> {
+    let file = File::create(archive_path)
+        .map_err(|e| AppError::InvalidState(format!("Failed to create archive file: {}", e)))?;
+
+    // Use fast compression (level 1) for speed
+    let encoder = GzEncoder::new(file, Compression::fast());
+    let mut builder = Builder::new(encoder);
+
+    if mods_dir.exists() {
+        // Add all contents of mods directory to the archive
+        let entries = fs::read_dir(mods_dir)
+            .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+
+            // Skip hidden files and known non-mod directories
+            if let Some(name_str) = name.to_str() {
+                let lower = name_str.to_lowercase();
+                if lower.starts_with('.')
+                    || lower.contains("lovely")
+                    || matches!(lower.as_str(), ".git" | "node_modules" | "__macosx")
+                {
+                    continue;
+                }
+            }
+
+            if path.is_dir() {
+                builder.append_dir_all(&name, &path).map_err(|e| {
+                    AppError::InvalidState(format!("Failed to add directory to archive: {}", e))
+                })?;
+            } else if path.is_file() {
+                builder.append_path_with_name(&path, &name).map_err(|e| {
+                    AppError::InvalidState(format!("Failed to add file to archive: {}", e))
+                })?;
+            }
+        }
+    }
+
+    builder
+        .finish()
+        .map_err(|e| AppError::InvalidState(format!("Failed to finish archive: {}", e)))?;
+
+    Ok(())
+}
+
+/// List all backups, sorted by creation time (newest first).
+pub fn list_backups() -> Result<Vec<BackupMetadata>, AppError> {
+    let backups_dir = get_backups_dir()?;
+
+    if !backups_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let entries = fs::read_dir(&backups_dir)
+        .map_err(|e| AppError::InvalidState(format!("Failed to read backups directory: {}", e)))?;
+
+    let mut backups = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let metadata_path = path.join("metadata.json");
+        if !metadata_path.exists() {
+            continue;
+        }
+
+        match fs::read_to_string(&metadata_path) {
+            Ok(content) => match serde_json::from_str::<BackupMetadata>(&content) {
+                Ok(metadata) => backups.push(metadata),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to parse backup metadata at {:?}: {}",
+                        metadata_path,
+                        e
+                    );
+                }
+            },
+            Err(e) => {
+                log::warn!(
+                    "Failed to read backup metadata at {:?}: {}",
+                    metadata_path,
+                    e
+                );
+            }
+        }
+    }
+
+    // Sort by creation time, newest first
+    backups.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    Ok(backups)
+}
+
+/// Restore a backup by ID.
+///
+/// This will:
+/// 1. Validate the backup integrity
+/// 2. Remove current mods folder contents
+/// 3. Extract the backup archive
+/// 4. Restore database state
+/// 5. Restore enabled/disabled states
+pub async fn restore_backup(backup_id: &str) -> Result<(), AppError> {
+    let backups_dir = get_backups_dir()?;
+    let backup_dir = backups_dir.join(backup_id);
+
+    if !backup_dir.exists() {
+        return Err(AppError::InvalidState(format!(
+            "Backup '{}' not found",
+            backup_id
+        )));
+    }
+
+    let archive_path = backup_dir.join("mods.tar.gz");
+    let db_snapshot_path = backup_dir.join("database.json");
+
+    // Validate backup integrity
+    if !archive_path.exists() {
+        return Err(AppError::InvalidState(format!(
+            "Backup '{}' is corrupted: missing mods archive",
+            backup_id
+        )));
+    }
+
+    if !db_snapshot_path.exists() {
+        return Err(AppError::InvalidState(format!(
+            "Backup '{}' is corrupted: missing database snapshot",
+            backup_id
+        )));
+    }
+
+    // Read database snapshot
+    let db_content = fs::read_to_string(&db_snapshot_path)
+        .map_err(|e| AppError::InvalidState(format!("Failed to read database snapshot: {}", e)))?;
+
+    let db_snapshot: DatabaseSnapshot = serde_json::from_str(&db_content)
+        .map_err(|e| AppError::InvalidState(format!("Failed to parse database snapshot: {}", e)))?;
+
+    let mods_dir = crate::mods_dir();
+
+    // Create a marker file to indicate restore is in progress
+    let restore_marker = mods_dir
+        .parent()
+        .unwrap_or(&mods_dir)
+        .join(".restore_in_progress");
+
+    fs::write(&restore_marker, backup_id)
+        .map_err(|e| AppError::InvalidState(format!("Failed to create restore marker: {}", e)))?;
+
+    // Extract to a temporary directory first (atomic approach)
+    let temp_dir = mods_dir
+        .parent()
+        .unwrap_or(&mods_dir)
+        .join(".mods_restore_temp");
+
+    // Clean up any previous failed restore
+    if temp_dir.exists() {
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    fs::create_dir_all(&temp_dir).map_err(|e| AppError::DirCreate {
+        path: temp_dir.clone(),
+        source: e.to_string(),
+    })?;
+
+    // Extract archive to temp directory
+    extract_mods_archive(&archive_path, &temp_dir)?;
+
+    // Clear current mods folder (except Lovely-related files)
+    clear_mods_folder(&mods_dir)?;
+
+    // Move extracted mods to mods folder
+    move_restored_mods(&temp_dir, &mods_dir)?;
+
+    // Restore database state
+    let db = Database::new()?;
+    restore_database_state(&db, &db_snapshot)?;
+
+    // Restore enabled/disabled states
+    restore_enabled_states(&mods_dir, &db_snapshot.disabled_mods)?;
+
+    // Clean up
+    let _ = fs::remove_dir_all(&temp_dir);
+    let _ = fs::remove_file(&restore_marker);
+
+    // Clear mod detection cache to reflect new state
+    crate::local_mod_detection::clear_detection_cache();
+
+    log::info!("Successfully restored backup '{}'", backup_id);
+
+    Ok(())
+}
+
+/// Extract the mods archive to a directory.
+fn extract_mods_archive(archive_path: &Path, dest_dir: &Path) -> Result<(), AppError> {
+    let file = File::open(archive_path)
+        .map_err(|e| AppError::InvalidState(format!("Failed to open archive: {}", e)))?;
+
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+
+    archive
+        .unpack(dest_dir)
+        .map_err(|e| AppError::InvalidState(format!("Failed to extract archive: {}", e)))?;
+
+    Ok(())
+}
+
+/// Clear the mods folder, preserving Lovely-related files.
+fn clear_mods_folder(mods_dir: &Path) -> Result<(), AppError> {
+    if !mods_dir.exists() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(mods_dir)
+        .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+
+        // Skip Lovely-related files and hidden files
+        if let Some(name_str) = name.to_str() {
+            let lower = name_str.to_lowercase();
+            if lower.contains("lovely") || lower.starts_with('.') {
+                continue;
+            }
+        }
+
+        if path.is_dir() {
+            fs::remove_dir_all(&path).map_err(|e| {
+                AppError::InvalidState(format!("Failed to remove directory {:?}: {}", path, e))
+            })?;
+        } else {
+            fs::remove_file(&path).map_err(|e| {
+                AppError::InvalidState(format!("Failed to remove file {:?}: {}", path, e))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Move restored mods from temp directory to mods folder.
+fn move_restored_mods(temp_dir: &Path, mods_dir: &Path) -> Result<(), AppError> {
+    if !temp_dir.exists() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(temp_dir)
+        .map_err(|e| AppError::InvalidState(format!("Failed to read temp directory: {}", e)))?;
+
+    for entry in entries.flatten() {
+        let src_path = entry.path();
+        let dest_path = mods_dir.join(entry.file_name());
+
+        if src_path.is_dir() {
+            // Use rename if possible (same filesystem), otherwise copy
+            if fs::rename(&src_path, &dest_path).is_err() {
+                copy_dir_recursive(&src_path, &dest_path)?;
+                let _ = fs::remove_dir_all(&src_path);
+            }
+        } else if fs::rename(&src_path, &dest_path).is_err() {
+            fs::copy(&src_path, &dest_path)
+                .map_err(|e| AppError::InvalidState(format!("Failed to copy file: {}", e)))?;
+            let _ = fs::remove_file(&src_path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Recursively copy a directory.
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), AppError> {
+    fs::create_dir_all(dest).map_err(|e| AppError::DirCreate {
+        path: dest.to_path_buf(),
+        source: e.to_string(),
+    })?;
+
+    let entries = fs::read_dir(src).map_err(|e| {
+        AppError::InvalidState(format!("Failed to read directory {:?}: {}", src, e))
+    })?;
+
+    for entry in entries.flatten() {
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path)?;
+        } else {
+            fs::copy(&src_path, &dest_path)
+                .map_err(|e| AppError::InvalidState(format!("Failed to copy file: {}", e)))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Restore the database state from a snapshot.
+fn restore_database_state(db: &Database, snapshot: &DatabaseSnapshot) -> Result<(), AppError> {
+    // Clear existing installed mods
+    for existing in db.get_installed_mods()? {
+        db.remove_installed_mod(&existing.name)?;
+    }
+
+    // Add mods from snapshot
+    for mod_record in &snapshot.installed_mods {
+        db.add_installed_mod(
+            &mod_record.name,
+            &mod_record.path,
+            &mod_record.dependencies,
+            mod_record.current_version.clone(),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Restore enabled/disabled states for mods.
+fn restore_enabled_states(mods_dir: &Path, disabled_mods: &[String]) -> Result<(), AppError> {
+    // First, remove all .lovelyignore files
+    if mods_dir.exists() {
+        let entries = fs::read_dir(mods_dir)
+            .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let ignore_file = path.join(".lovelyignore");
+                let _ = fs::remove_file(&ignore_file);
+            }
+        }
+    }
+
+    // Add .lovelyignore files for disabled mods
+    for mod_name in disabled_mods {
+        let mod_path = mods_dir.join(mod_name);
+        if mod_path.exists() && mod_path.is_dir() {
+            let ignore_file = mod_path.join(".lovelyignore");
+            fs::write(&ignore_file, "").map_err(|e| {
+                AppError::InvalidState(format!(
+                    "Failed to create .lovelyignore for {}: {}",
+                    mod_name, e
+                ))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete a backup by ID.
+pub fn delete_backup(backup_id: &str) -> Result<(), AppError> {
+    let backups_dir = get_backups_dir()?;
+    let backup_dir = backups_dir.join(backup_id);
+
+    if !backup_dir.exists() {
+        return Err(AppError::InvalidState(format!(
+            "Backup '{}' not found",
+            backup_id
+        )));
+    }
+
+    fs::remove_dir_all(&backup_dir)
+        .map_err(|e| AppError::InvalidState(format!("Failed to delete backup: {}", e)))?;
+
+    log::info!("Deleted backup '{}'", backup_id);
+
+    Ok(())
+}
+
+/// Enforce the retention policy for automatic backups.
+/// Keeps only the most recent MAX_AUTO_BACKUPS automatic backups.
+pub fn enforce_retention() -> Result<(), AppError> {
+    let backups = list_backups()?;
+
+    // Filter to only auto backups
+    let auto_backups: Vec<_> = backups.iter().filter(|b| b.trigger.is_auto()).collect();
+
+    // Delete oldest auto backups if we exceed the limit
+    if auto_backups.len() > MAX_AUTO_BACKUPS {
+        for backup in auto_backups.iter().skip(MAX_AUTO_BACKUPS) {
+            if let Err(e) = delete_backup(&backup.id) {
+                log::warn!("Failed to delete old backup '{}': {}", backup.id, e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Get the total size of all backups in bytes.
+pub fn get_total_backups_size() -> Result<u64, AppError> {
+    let backups = list_backups()?;
+    Ok(backups.iter().map(|b| b.size_bytes).sum())
+}
+
+/// Check if a restore was interrupted and return the backup ID if so.
+pub fn check_interrupted_restore() -> Option<String> {
+    let config_dir = dirs::config_dir()?;
+    let restore_marker = config_dir.join("Balatro").join(".restore_in_progress");
+
+    if restore_marker.exists() {
+        fs::read_to_string(&restore_marker).ok()
+    } else {
+        None
+    }
+}
+
+/// Clear the interrupted restore marker.
+pub fn clear_interrupted_restore_marker() -> Result<(), AppError> {
+    let config_dir = dirs::config_dir()
+        .ok_or_else(|| AppError::DirNotFound(PathBuf::from("config directory")))?;
+    let restore_marker = config_dir.join("Balatro").join(".restore_in_progress");
+
+    if restore_marker.exists() {
+        fs::remove_file(&restore_marker).map_err(|e| {
+            AppError::InvalidState(format!("Failed to remove restore marker: {}", e))
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_backup_trigger_is_auto() {
+        assert!(BackupTrigger::AutoUpdate.is_auto());
+        assert!(BackupTrigger::AutoUninstall.is_auto());
+        assert!(BackupTrigger::AutoBulk.is_auto());
+        assert!(!BackupTrigger::Manual.is_auto());
+    }
+
+    #[test]
+    fn test_backup_trigger_description() {
+        assert_eq!(
+            BackupTrigger::AutoUpdate.description(),
+            "Before updating mod"
+        );
+        assert_eq!(BackupTrigger::Manual.description(), "Manual backup");
+    }
+
+    #[test]
+    fn test_mod_record_from_installed_mod() {
+        let installed = InstalledMod {
+            name: "TestMod".to_string(),
+            path: "/path/to/mod".to_string(),
+            dependencies: vec!["Steamodded".to_string()],
+            current_version: Some("1.0.0".to_string()),
+        };
+
+        let record = ModRecord::from(installed);
+        assert_eq!(record.name, "TestMod");
+        assert_eq!(record.path, "/path/to/mod");
+        assert_eq!(record.dependencies, vec!["Steamodded"]);
+        assert_eq!(record.current_version, Some("1.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_find_disabled_mods() {
+        let temp_dir = TempDir::new().unwrap();
+        let mods_dir = temp_dir.path();
+
+        // Create some mod directories
+        let mod1 = mods_dir.join("EnabledMod");
+        let mod2 = mods_dir.join("DisabledMod");
+        fs::create_dir_all(&mod1).unwrap();
+        fs::create_dir_all(&mod2).unwrap();
+
+        // Add .lovelyignore to disabled mod
+        fs::write(mod2.join(".lovelyignore"), "").unwrap();
+
+        let disabled = find_disabled_mods(mods_dir).unwrap();
+        assert_eq!(disabled, vec!["DisabledMod"]);
+    }
+
+    #[test]
+    fn test_create_and_extract_archive() {
+        let temp_dir = TempDir::new().unwrap();
+        let mods_dir = temp_dir.path().join("mods");
+        let archive_path = temp_dir.path().join("test.tar.gz");
+        let extract_dir = temp_dir.path().join("extracted");
+
+        // Create test mod structure
+        let test_mod = mods_dir.join("TestMod");
+        fs::create_dir_all(&test_mod).unwrap();
+        fs::write(test_mod.join("main.lua"), "-- test mod").unwrap();
+        fs::write(test_mod.join("config.json"), "{}").unwrap();
+
+        // Create archive
+        create_mods_archive(&mods_dir, &archive_path).unwrap();
+        assert!(archive_path.exists());
+
+        // Extract archive
+        fs::create_dir_all(&extract_dir).unwrap();
+        extract_mods_archive(&archive_path, &extract_dir).unwrap();
+
+        // Verify extracted contents
+        let extracted_mod = extract_dir.join("TestMod");
+        assert!(extracted_mod.exists());
+        assert!(extracted_mod.join("main.lua").exists());
+        assert!(extracted_mod.join("config.json").exists());
+    }
+}

--- a/src-tauri/bmm-lib/src/backup.rs
+++ b/src-tauri/bmm-lib/src/backup.rs
@@ -796,13 +796,15 @@ mod tests {
         // Create some mod directories
         let mod1 = mods_dir.join("EnabledMod");
         let mod2 = mods_dir.join("DisabledMod");
-        fs::create_dir_all(&mod1).unwrap();
-        fs::create_dir_all(&mod2).unwrap();
+        std::fs::create_dir_all(&mod1).unwrap();
+        std::fs::create_dir_all(&mod2).unwrap();
 
         // Add .lovelyignore to disabled mod
-        fs::write(mod2.join(".lovelyignore"), "").unwrap();
+        std::fs::write(mod2.join(".lovelyignore"), "").unwrap();
 
-        let disabled = find_disabled_mods(mods_dir).unwrap();
+        // Use tokio runtime for async test
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let disabled = rt.block_on(find_disabled_mods(mods_dir)).unwrap();
         assert_eq!(disabled, vec!["DisabledMod"]);
     }
 
@@ -815,17 +817,17 @@ mod tests {
 
         // Create test mod structure
         let test_mod = mods_dir.join("TestMod");
-        fs::create_dir_all(&test_mod).unwrap();
-        fs::write(test_mod.join("main.lua"), "-- test mod").unwrap();
-        fs::write(test_mod.join("config.json"), "{}").unwrap();
+        std::fs::create_dir_all(&test_mod).unwrap();
+        std::fs::write(test_mod.join("main.lua"), "-- test mod").unwrap();
+        std::fs::write(test_mod.join("config.json"), "{}").unwrap();
 
         // Create archive
-        create_mods_archive(&mods_dir, &archive_path).unwrap();
+        create_mods_archive_sync(&mods_dir, &archive_path).unwrap();
         assert!(archive_path.exists());
 
         // Extract archive
-        fs::create_dir_all(&extract_dir).unwrap();
-        extract_mods_archive(&archive_path, &extract_dir).unwrap();
+        std::fs::create_dir_all(&extract_dir).unwrap();
+        extract_mods_archive_sync(&archive_path, &extract_dir).unwrap();
 
         // Verify extracted contents
         let extracted_mod = extract_dir.join("TestMod");

--- a/src-tauri/bmm-lib/src/backup.rs
+++ b/src-tauri/bmm-lib/src/backup.rs
@@ -10,9 +10,10 @@ use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use serde::{Deserialize, Serialize};
-use std::fs::{self, File};
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use tar::{Archive, Builder};
+use tokio::fs;
 
 /// Maximum number of automatic backups to retain.
 const MAX_AUTO_BACKUPS: usize = 5;
@@ -128,7 +129,7 @@ pub async fn create_backup(
 
     // Check if we should debounce auto-backups
     if trigger.is_auto()
-        && let Ok(backups) = list_backups()
+        && let Ok(backups) = list_backups().await
         && let Some(latest) = backups.first()
     {
         let elapsed = Utc::now()
@@ -145,10 +146,12 @@ pub async fn create_backup(
     }
 
     // Create backups directory if it doesn't exist
-    fs::create_dir_all(&backups_dir).map_err(|e| AppError::DirCreate {
-        path: backups_dir.clone(),
-        source: e.to_string(),
-    })?;
+    fs::create_dir_all(&backups_dir)
+        .await
+        .map_err(|e| AppError::DirCreate {
+            path: backups_dir.clone(),
+            source: e.to_string(),
+        })?;
 
     // Generate backup ID and directory name
     let now = Utc::now();
@@ -162,10 +165,12 @@ pub async fn create_backup(
     let id = format!("{}_{}", now.format("%Y%m%d_%H%M%S"), trigger_str);
     let backup_dir = backups_dir.join(&id);
 
-    fs::create_dir_all(&backup_dir).map_err(|e| AppError::DirCreate {
-        path: backup_dir.clone(),
-        source: e.to_string(),
-    })?;
+    fs::create_dir_all(&backup_dir)
+        .await
+        .map_err(|e| AppError::DirCreate {
+            path: backup_dir.clone(),
+            source: e.to_string(),
+        })?;
 
     // Get database state
     let db = Database::new()?;
@@ -174,7 +179,7 @@ pub async fn create_backup(
     let lovely_version = db.get_lovely_version().ok().flatten();
 
     // Find disabled mods (those with .lovelyignore files)
-    let disabled_mods = find_disabled_mods(&mods_dir)?;
+    let disabled_mods = find_disabled_mods(&mods_dir).await?;
 
     // Create database snapshot
     let db_snapshot = DatabaseSnapshot {
@@ -185,15 +190,26 @@ pub async fn create_backup(
     let db_snapshot_path = backup_dir.join("database.json");
     let db_json = serde_json::to_string_pretty(&db_snapshot)?;
     fs::write(&db_snapshot_path, &db_json)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to write database snapshot: {}", e)))?;
 
-    // Create compressed tar archive of mods folder
+    // Create compressed tar archive of mods folder (CPU-intensive, run in blocking task)
     let archive_path = backup_dir.join("mods.tar.gz");
-    create_mods_archive(&mods_dir, &archive_path)?;
+    let mods_dir_clone = mods_dir.clone();
+    let archive_path_clone = archive_path.clone();
+    tokio::task::spawn_blocking(move || {
+        create_mods_archive_sync(&mods_dir_clone, &archive_path_clone)
+    })
+    .await
+    .map_err(|e| AppError::InvalidState(format!("Archive task failed: {}", e)))??;
 
     // Calculate total size
-    let archive_size = fs::metadata(&archive_path).map(|m| m.len()).unwrap_or(0);
+    let archive_size = fs::metadata(&archive_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
     let db_size = fs::metadata(&db_snapshot_path)
+        .await
         .map(|m| m.len())
         .unwrap_or(0);
     let size_bytes = archive_size + db_size;
@@ -220,10 +236,11 @@ pub async fn create_backup(
     let metadata_path = backup_dir.join("metadata.json");
     let metadata_json = serde_json::to_string_pretty(&metadata)?;
     fs::write(&metadata_path, &metadata_json)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to write backup metadata: {}", e)))?;
 
     // Enforce retention policy for auto-backups
-    enforce_retention()?;
+    enforce_retention().await?;
 
     log::info!(
         "Created backup '{}': {} mods, {} bytes",
@@ -236,17 +253,22 @@ pub async fn create_backup(
 }
 
 /// Find mods that have .lovelyignore files (disabled mods).
-fn find_disabled_mods(mods_dir: &Path) -> Result<Vec<String>, AppError> {
+async fn find_disabled_mods(mods_dir: &Path) -> Result<Vec<String>, AppError> {
     let mut disabled = Vec::new();
 
     if !mods_dir.exists() {
         return Ok(disabled);
     }
 
-    let entries = fs::read_dir(mods_dir)
+    let mut entries = fs::read_dir(mods_dir)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
 
-    for entry in entries.flatten() {
+    while let Some(entry) = entries.next_entry().await.transpose() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
         let path = entry.path();
         if path.is_dir() {
             let ignore_file = path.join(".lovelyignore");
@@ -261,8 +283,8 @@ fn find_disabled_mods(mods_dir: &Path) -> Result<Vec<String>, AppError> {
     Ok(disabled)
 }
 
-/// Create a compressed tar archive of the mods folder.
-fn create_mods_archive(mods_dir: &Path, archive_path: &Path) -> Result<(), AppError> {
+/// Create a compressed tar archive of the mods folder (synchronous, CPU-intensive).
+fn create_mods_archive_sync(mods_dir: &Path, archive_path: &Path) -> Result<(), AppError> {
     let file = File::create(archive_path)
         .map_err(|e| AppError::InvalidState(format!("Failed to create archive file: {}", e)))?;
 
@@ -272,7 +294,7 @@ fn create_mods_archive(mods_dir: &Path, archive_path: &Path) -> Result<(), AppEr
 
     if mods_dir.exists() {
         // Add all contents of mods directory to the archive
-        let entries = fs::read_dir(mods_dir)
+        let entries = std::fs::read_dir(mods_dir)
             .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
 
         for entry in entries.flatten() {
@@ -310,19 +332,24 @@ fn create_mods_archive(mods_dir: &Path, archive_path: &Path) -> Result<(), AppEr
 }
 
 /// List all backups, sorted by creation time (newest first).
-pub fn list_backups() -> Result<Vec<BackupMetadata>, AppError> {
+pub async fn list_backups() -> Result<Vec<BackupMetadata>, AppError> {
     let backups_dir = get_backups_dir()?;
 
     if !backups_dir.exists() {
         return Ok(Vec::new());
     }
 
-    let entries = fs::read_dir(&backups_dir)
+    let mut entries = fs::read_dir(&backups_dir)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to read backups directory: {}", e)))?;
 
     let mut backups = Vec::new();
 
-    for entry in entries.flatten() {
+    while let Some(entry) = entries.next_entry().await.transpose() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
         let path = entry.path();
         if !path.is_dir() {
             continue;
@@ -333,7 +360,7 @@ pub fn list_backups() -> Result<Vec<BackupMetadata>, AppError> {
             continue;
         }
 
-        match fs::read_to_string(&metadata_path) {
+        match fs::read_to_string(&metadata_path).await {
             Ok(content) => match serde_json::from_str::<BackupMetadata>(&content) {
                 Ok(metadata) => backups.push(metadata),
                 Err(e) => {
@@ -399,6 +426,7 @@ pub async fn restore_backup(backup_id: &str) -> Result<(), AppError> {
 
     // Read database snapshot
     let db_content = fs::read_to_string(&db_snapshot_path)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to read database snapshot: {}", e)))?;
 
     let db_snapshot: DatabaseSnapshot = serde_json::from_str(&db_content)
@@ -413,6 +441,7 @@ pub async fn restore_backup(backup_id: &str) -> Result<(), AppError> {
         .join(".restore_in_progress");
 
     fs::write(&restore_marker, backup_id)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to create restore marker: {}", e)))?;
 
     // Extract to a temporary directory first (atomic approach)
@@ -423,33 +452,41 @@ pub async fn restore_backup(backup_id: &str) -> Result<(), AppError> {
 
     // Clean up any previous failed restore
     if temp_dir.exists() {
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = fs::remove_dir_all(&temp_dir).await;
     }
 
-    fs::create_dir_all(&temp_dir).map_err(|e| AppError::DirCreate {
-        path: temp_dir.clone(),
-        source: e.to_string(),
-    })?;
+    fs::create_dir_all(&temp_dir)
+        .await
+        .map_err(|e| AppError::DirCreate {
+            path: temp_dir.clone(),
+            source: e.to_string(),
+        })?;
 
-    // Extract archive to temp directory
-    extract_mods_archive(&archive_path, &temp_dir)?;
+    // Extract archive to temp directory (CPU-intensive, run in blocking task)
+    let archive_path_clone = archive_path.clone();
+    let temp_dir_clone = temp_dir.clone();
+    tokio::task::spawn_blocking(move || {
+        extract_mods_archive_sync(&archive_path_clone, &temp_dir_clone)
+    })
+    .await
+    .map_err(|e| AppError::InvalidState(format!("Extract task failed: {}", e)))??;
 
     // Clear current mods folder (except Lovely-related files)
-    clear_mods_folder(&mods_dir)?;
+    clear_mods_folder(&mods_dir).await?;
 
     // Move extracted mods to mods folder
-    move_restored_mods(&temp_dir, &mods_dir)?;
+    move_restored_mods(&temp_dir, &mods_dir).await?;
 
     // Restore database state
     let db = Database::new()?;
     restore_database_state(&db, &db_snapshot)?;
 
     // Restore enabled/disabled states
-    restore_enabled_states(&mods_dir, &db_snapshot.disabled_mods)?;
+    restore_enabled_states(&mods_dir, &db_snapshot.disabled_mods).await?;
 
     // Clean up
-    let _ = fs::remove_dir_all(&temp_dir);
-    let _ = fs::remove_file(&restore_marker);
+    let _ = fs::remove_dir_all(&temp_dir).await;
+    let _ = fs::remove_file(&restore_marker).await;
 
     // Clear mod detection cache to reflect new state
     crate::local_mod_detection::clear_detection_cache();
@@ -459,8 +496,8 @@ pub async fn restore_backup(backup_id: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Extract the mods archive to a directory.
-fn extract_mods_archive(archive_path: &Path, dest_dir: &Path) -> Result<(), AppError> {
+/// Extract the mods archive to a directory (synchronous, CPU-intensive).
+fn extract_mods_archive_sync(archive_path: &Path, dest_dir: &Path) -> Result<(), AppError> {
     let file = File::open(archive_path)
         .map_err(|e| AppError::InvalidState(format!("Failed to open archive: {}", e)))?;
 
@@ -475,15 +512,20 @@ fn extract_mods_archive(archive_path: &Path, dest_dir: &Path) -> Result<(), AppE
 }
 
 /// Clear the mods folder, preserving Lovely-related files.
-fn clear_mods_folder(mods_dir: &Path) -> Result<(), AppError> {
+async fn clear_mods_folder(mods_dir: &Path) -> Result<(), AppError> {
     if !mods_dir.exists() {
         return Ok(());
     }
 
-    let entries = fs::read_dir(mods_dir)
+    let mut entries = fs::read_dir(mods_dir)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
 
-    for entry in entries.flatten() {
+    while let Some(entry) = entries.next_entry().await.transpose() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
         let path = entry.path();
         let name = entry.file_name();
 
@@ -496,11 +538,11 @@ fn clear_mods_folder(mods_dir: &Path) -> Result<(), AppError> {
         }
 
         if path.is_dir() {
-            fs::remove_dir_all(&path).map_err(|e| {
+            fs::remove_dir_all(&path).await.map_err(|e| {
                 AppError::InvalidState(format!("Failed to remove directory {:?}: {}", path, e))
             })?;
         } else {
-            fs::remove_file(&path).map_err(|e| {
+            fs::remove_file(&path).await.map_err(|e| {
                 AppError::InvalidState(format!("Failed to remove file {:?}: {}", path, e))
             })?;
         }
@@ -510,42 +552,54 @@ fn clear_mods_folder(mods_dir: &Path) -> Result<(), AppError> {
 }
 
 /// Move restored mods from temp directory to mods folder.
-fn move_restored_mods(temp_dir: &Path, mods_dir: &Path) -> Result<(), AppError> {
+async fn move_restored_mods(temp_dir: &Path, mods_dir: &Path) -> Result<(), AppError> {
     if !temp_dir.exists() {
         return Ok(());
     }
 
-    let entries = fs::read_dir(temp_dir)
+    let mut entries = fs::read_dir(temp_dir)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to read temp directory: {}", e)))?;
 
-    for entry in entries.flatten() {
+    while let Some(entry) = entries.next_entry().await.transpose() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
         let src_path = entry.path();
         let dest_path = mods_dir.join(entry.file_name());
 
         if src_path.is_dir() {
             // Use rename if possible (same filesystem), otherwise copy
-            if fs::rename(&src_path, &dest_path).is_err() {
-                copy_dir_recursive(&src_path, &dest_path)?;
-                let _ = fs::remove_dir_all(&src_path);
+            if fs::rename(&src_path, &dest_path).await.is_err() {
+                let src_clone = src_path.clone();
+                let dest_clone = dest_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    copy_dir_recursive_sync(&src_clone, &dest_clone)
+                })
+                .await
+                .map_err(|e| AppError::InvalidState(format!("Copy task failed: {}", e)))??;
+                let _ = fs::remove_dir_all(&src_path).await;
             }
-        } else if fs::rename(&src_path, &dest_path).is_err() {
+        } else if fs::rename(&src_path, &dest_path).await.is_err() {
             fs::copy(&src_path, &dest_path)
+                .await
                 .map_err(|e| AppError::InvalidState(format!("Failed to copy file: {}", e)))?;
-            let _ = fs::remove_file(&src_path);
+            let _ = fs::remove_file(&src_path).await;
         }
     }
 
     Ok(())
 }
 
-/// Recursively copy a directory.
-fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), AppError> {
-    fs::create_dir_all(dest).map_err(|e| AppError::DirCreate {
+/// Recursively copy a directory (synchronous, for spawn_blocking).
+fn copy_dir_recursive_sync(src: &Path, dest: &Path) -> Result<(), AppError> {
+    std::fs::create_dir_all(dest).map_err(|e| AppError::DirCreate {
         path: dest.to_path_buf(),
         source: e.to_string(),
     })?;
 
-    let entries = fs::read_dir(src).map_err(|e| {
+    let entries = std::fs::read_dir(src).map_err(|e| {
         AppError::InvalidState(format!("Failed to read directory {:?}: {}", src, e))
     })?;
 
@@ -554,9 +608,9 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), AppError> {
         let dest_path = dest.join(entry.file_name());
 
         if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dest_path)?;
+            copy_dir_recursive_sync(&src_path, &dest_path)?;
         } else {
-            fs::copy(&src_path, &dest_path)
+            std::fs::copy(&src_path, &dest_path)
                 .map_err(|e| AppError::InvalidState(format!("Failed to copy file: {}", e)))?;
         }
     }
@@ -585,17 +639,22 @@ fn restore_database_state(db: &Database, snapshot: &DatabaseSnapshot) -> Result<
 }
 
 /// Restore enabled/disabled states for mods.
-fn restore_enabled_states(mods_dir: &Path, disabled_mods: &[String]) -> Result<(), AppError> {
+async fn restore_enabled_states(mods_dir: &Path, disabled_mods: &[String]) -> Result<(), AppError> {
     // First, remove all .lovelyignore files
     if mods_dir.exists() {
-        let entries = fs::read_dir(mods_dir)
+        let mut entries = fs::read_dir(mods_dir)
+            .await
             .map_err(|e| AppError::InvalidState(format!("Failed to read mods directory: {}", e)))?;
 
-        for entry in entries.flatten() {
+        while let Some(entry) = entries.next_entry().await.transpose() {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
             let path = entry.path();
             if path.is_dir() {
                 let ignore_file = path.join(".lovelyignore");
-                let _ = fs::remove_file(&ignore_file);
+                let _ = fs::remove_file(&ignore_file).await;
             }
         }
     }
@@ -605,7 +664,7 @@ fn restore_enabled_states(mods_dir: &Path, disabled_mods: &[String]) -> Result<(
         let mod_path = mods_dir.join(mod_name);
         if mod_path.exists() && mod_path.is_dir() {
             let ignore_file = mod_path.join(".lovelyignore");
-            fs::write(&ignore_file, "").map_err(|e| {
+            fs::write(&ignore_file, "").await.map_err(|e| {
                 AppError::InvalidState(format!(
                     "Failed to create .lovelyignore for {}: {}",
                     mod_name, e
@@ -618,7 +677,7 @@ fn restore_enabled_states(mods_dir: &Path, disabled_mods: &[String]) -> Result<(
 }
 
 /// Delete a backup by ID.
-pub fn delete_backup(backup_id: &str) -> Result<(), AppError> {
+pub async fn delete_backup(backup_id: &str) -> Result<(), AppError> {
     let backups_dir = get_backups_dir()?;
     let backup_dir = backups_dir.join(backup_id);
 
@@ -630,6 +689,7 @@ pub fn delete_backup(backup_id: &str) -> Result<(), AppError> {
     }
 
     fs::remove_dir_all(&backup_dir)
+        .await
         .map_err(|e| AppError::InvalidState(format!("Failed to delete backup: {}", e)))?;
 
     log::info!("Deleted backup '{}'", backup_id);
@@ -639,8 +699,8 @@ pub fn delete_backup(backup_id: &str) -> Result<(), AppError> {
 
 /// Enforce the retention policy for automatic backups.
 /// Keeps only the most recent MAX_AUTO_BACKUPS automatic backups.
-pub fn enforce_retention() -> Result<(), AppError> {
-    let backups = list_backups()?;
+pub async fn enforce_retention() -> Result<(), AppError> {
+    let backups = list_backups().await?;
 
     // Filter to only auto backups
     let auto_backups: Vec<_> = backups.iter().filter(|b| b.trigger.is_auto()).collect();
@@ -648,7 +708,7 @@ pub fn enforce_retention() -> Result<(), AppError> {
     // Delete oldest auto backups if we exceed the limit
     if auto_backups.len() > MAX_AUTO_BACKUPS {
         for backup in auto_backups.iter().skip(MAX_AUTO_BACKUPS) {
-            if let Err(e) = delete_backup(&backup.id) {
+            if let Err(e) = delete_backup(&backup.id).await {
                 log::warn!("Failed to delete old backup '{}': {}", backup.id, e);
             }
         }
@@ -658,8 +718,8 @@ pub fn enforce_retention() -> Result<(), AppError> {
 }
 
 /// Get the total size of all backups in bytes.
-pub fn get_total_backups_size() -> Result<u64, AppError> {
-    let backups = list_backups()?;
+pub async fn get_total_backups_size() -> Result<u64, AppError> {
+    let backups = list_backups().await?;
     Ok(backups.iter().map(|b| b.size_bytes).sum())
 }
 
@@ -669,7 +729,7 @@ pub fn check_interrupted_restore() -> Option<String> {
     let restore_marker = config_dir.join("Balatro").join(".restore_in_progress");
 
     if restore_marker.exists() {
-        fs::read_to_string(&restore_marker).ok()
+        std::fs::read_to_string(&restore_marker).ok()
     } else {
         None
     }
@@ -682,7 +742,7 @@ pub fn clear_interrupted_restore_marker() -> Result<(), AppError> {
     let restore_marker = config_dir.join("Balatro").join(".restore_in_progress");
 
     if restore_marker.exists() {
-        fs::remove_file(&restore_marker).map_err(|e| {
+        std::fs::remove_file(&restore_marker).map_err(|e| {
             AppError::InvalidState(format!("Failed to remove restore marker: {}", e))
         })?;
     }

--- a/src-tauri/bmm-lib/src/lib.rs
+++ b/src-tauri/bmm-lib/src/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! # Modules
 //!
+//! - [`backup`]: Backup and restore functionality for mod snapshots
 //! - [`balamod`]: Balamod (alternative mod loader) support and Balatro game detection
 //! - [`cache`]: Binary cache for remote mod index data
 //! - [`database`]: SQLite database for storing app settings and installed mod metadata
@@ -19,6 +20,8 @@
 //! - [`rate_limiter`]: Rate limiter for GitHub API requests
 //! - [`smods_installer`]: Steamodded/Talisman installer
 
+/// Backup and restore functionality for mod snapshots.
+pub mod backup;
 /// Balamod support and Balatro game detection.
 pub mod balamod;
 /// Binary cache for remote mod index data.

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -1,0 +1,83 @@
+//! Tauri commands for backup and restore functionality.
+
+use bmm_lib::backup::{self, BackupMetadata, BackupTrigger};
+use serde::{Deserialize, Serialize};
+
+/// Serializable backup trigger for frontend communication.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackupTriggerInput {
+    AutoUpdate,
+    AutoUninstall,
+    AutoBulk,
+    Manual,
+}
+
+impl From<BackupTriggerInput> for BackupTrigger {
+    fn from(input: BackupTriggerInput) -> Self {
+        match input {
+            BackupTriggerInput::AutoUpdate => BackupTrigger::AutoUpdate,
+            BackupTriggerInput::AutoUninstall => BackupTrigger::AutoUninstall,
+            BackupTriggerInput::AutoBulk => BackupTrigger::AutoBulk,
+            BackupTriggerInput::Manual => BackupTrigger::Manual,
+        }
+    }
+}
+
+/// Create a new backup.
+#[tauri::command]
+pub async fn create_backup(
+    trigger: BackupTriggerInput,
+    name: Option<String>,
+    context: Option<String>,
+) -> Result<BackupMetadata, String> {
+    backup::create_backup(trigger.into(), name, context)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// List all available backups.
+#[tauri::command]
+pub async fn list_backups() -> Result<Vec<BackupMetadata>, String> {
+    backup::list_backups().map_err(|e| e.to_string())
+}
+
+/// Restore a backup by ID.
+#[tauri::command]
+pub async fn restore_backup(backup_id: String) -> Result<(), String> {
+    backup::restore_backup(&backup_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Delete a backup by ID.
+#[tauri::command]
+pub async fn delete_backup(backup_id: String) -> Result<(), String> {
+    backup::delete_backup(&backup_id).map_err(|e| e.to_string())
+}
+
+/// Get the total size of all backups in bytes.
+#[tauri::command]
+pub async fn get_backups_total_size() -> Result<u64, String> {
+    backup::get_total_backups_size().map_err(|e| e.to_string())
+}
+
+/// Get the backups directory path.
+#[tauri::command]
+pub async fn get_backups_directory() -> Result<String, String> {
+    backup::get_backups_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .map_err(|e| e.to_string())
+}
+
+/// Check if a restore was interrupted.
+#[tauri::command]
+pub async fn check_interrupted_restore() -> Result<Option<String>, String> {
+    Ok(backup::check_interrupted_restore())
+}
+
+/// Clear the interrupted restore marker.
+#[tauri::command]
+pub async fn clear_interrupted_restore() -> Result<(), String> {
+    backup::clear_interrupted_restore_marker().map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -39,7 +39,7 @@ pub async fn create_backup(
 /// List all available backups.
 #[tauri::command]
 pub async fn list_backups() -> Result<Vec<BackupMetadata>, String> {
-    backup::list_backups().map_err(|e| e.to_string())
+    backup::list_backups().await.map_err(|e| e.to_string())
 }
 
 /// Restore a backup by ID.
@@ -53,21 +53,32 @@ pub async fn restore_backup(backup_id: String) -> Result<(), String> {
 /// Delete a backup by ID.
 #[tauri::command]
 pub async fn delete_backup(backup_id: String) -> Result<(), String> {
-    backup::delete_backup(&backup_id).map_err(|e| e.to_string())
+    backup::delete_backup(&backup_id)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Get the total size of all backups in bytes.
 #[tauri::command]
 pub async fn get_backups_total_size() -> Result<u64, String> {
-    backup::get_total_backups_size().map_err(|e| e.to_string())
+    backup::get_total_backups_size()
+        .await
+        .map_err(|e| e.to_string())
 }
 
-/// Get the backups directory path.
+/// Get the backups directory path (creates it if it doesn't exist).
 #[tauri::command]
 pub async fn get_backups_directory() -> Result<String, String> {
-    backup::get_backups_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .map_err(|e| e.to_string())
+    let path = backup::get_backups_dir().map_err(|e| e.to_string())?;
+
+    // Create the directory if it doesn't exist
+    if !path.exists() {
+        tokio::fs::create_dir_all(&path)
+            .await
+            .map_err(|e| format!("Failed to create backups directory: {}", e))?;
+    }
+
+    Ok(path.to_string_lossy().to_string())
 }
 
 /// Check if a restore was interrupted.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod cache;
 pub mod detection;
 pub mod external;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -458,6 +458,14 @@ pub fn run() {
             commands::external::open_external_url,
             commands::init::get_app_init_data,
             commands::init::get_all_settings,
+            commands::backup::create_backup,
+            commands::backup::list_backups,
+            commands::backup::restore_backup,
+            commands::backup::delete_backup,
+            commands::backup::get_backups_total_size,
+            commands::backup::get_backups_directory,
+            commands::backup::check_interrupted_restore,
+            commands::backup::clear_interrupted_restore,
             exit_application
         ])
         .build(tauri::generate_context!());

--- a/src/components/BackupCard.svelte
+++ b/src/components/BackupCard.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import type { Backup } from "../stores/backups";
+  import {
+    formatBytes,
+    formatBackupDate,
+    getBackupDisplayName,
+  } from "../stores/backups";
+  import { restoreBackupPopupStore, deleteBackupPopupStore } from "../stores/modStore";
+  import { Archive, RotateCcw } from "lucide-svelte";
+
+  interface Props {
+    backup: Backup;
+  }
+
+  let { backup }: Props = $props();
+
+  const isManual = $derived(backup.trigger === "manual");
+
+  function openRestoreConfirm() {
+    restoreBackupPopupStore.set({
+      visible: true,
+      backupId: backup.id,
+      backupName: getBackupDisplayName(backup),
+    });
+  }
+
+  function openDeleteConfirm() {
+    deleteBackupPopupStore.set({
+      visible: true,
+      backupId: backup.id,
+      backupName: getBackupDisplayName(backup),
+    });
+  }
+</script>
+
+<div class="backup-card">
+  <div class="backup-icon" class:manual={isManual}>
+    {#if isManual}
+      <Archive size={24} />
+    {:else}
+      <RotateCcw size={24} />
+    {/if}
+  </div>
+  <div class="backup-info">
+    <div class="backup-name">{getBackupDisplayName(backup)}</div>
+    <div class="backup-metadata">
+      <span class="date">{formatBackupDate(backup.created_at)}</span>
+      <span class="separator">•</span>
+      <span class="mod-count">{backup.mod_count} mod{backup.mod_count !== 1 ? "s" : ""}</span>
+      <span class="separator">•</span>
+      <span class="size">{formatBytes(backup.size_bytes)}</span>
+    </div>
+    {#if backup.lovely_version}
+      <div class="lovely-version">Lovely: {backup.lovely_version}</div>
+    {/if}
+  </div>
+  <div class="backup-actions">
+    <button class="restore-button" onclick={openRestoreConfirm}>
+      Restore
+    </button>
+    <button class="delete-button" onclick={openDeleteConfirm}>
+      Delete
+    </button>
+  </div>
+</div>
+
+<style>
+  .backup-card {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1rem;
+    align-items: center;
+    background: rgba(244, 238, 224, 0.05);
+    border: 2px solid rgba(244, 238, 224, 0.3);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    transition: background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .backup-card:hover {
+    background: rgba(244, 238, 224, 0.08);
+    border-color: rgba(244, 238, 224, 0.4);
+  }
+
+  .backup-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 8px;
+    background: rgba(234, 150, 0, 0.2);
+    color: #ea9600;
+  }
+
+  .backup-icon.manual {
+    background: rgba(86, 167, 134, 0.2);
+    color: #56a786;
+  }
+
+  .backup-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .backup-name {
+    font-family: "M6X11", sans-serif;
+    font-size: 1.35rem;
+    color: #fdcf51;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .backup-metadata {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 1.1rem;
+    color: rgba(244, 238, 224, 0.8);
+  }
+
+  .separator {
+    opacity: 0.5;
+  }
+
+  .lovely-version {
+    font-size: 1rem;
+    color: rgba(244, 238, 224, 0.7);
+  }
+
+  .backup-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  button {
+    border: none;
+    border-radius: 6px;
+    padding: 0.7rem 1.1rem;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, background-color 0.2s ease;
+    box-shadow: 0 3px 0 rgba(0, 0, 0, 0.2);
+  }
+
+  button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 5px 0 rgba(0, 0, 0, 0.2);
+  }
+
+  button:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
+  }
+
+  .restore-button {
+    background: #56a786;
+    color: #f4eee0;
+    border: 2px solid #459373;
+  }
+
+  .restore-button:hover {
+    background: #67b897;
+  }
+
+  .delete-button {
+    background: #c14139;
+    color: #f4eee0;
+    border: 2px solid #a13029;
+  }
+
+  .delete-button:hover {
+    background: #d2524a;
+  }
+
+  @media (max-width: 768px) {
+    .backup-card {
+      grid-template-columns: 1fr;
+      gap: 0.75rem;
+      padding: 1rem;
+    }
+
+    .backup-icon {
+      display: none;
+    }
+
+    .backup-metadata {
+      flex-wrap: wrap;
+      font-size: 0.9rem;
+    }
+
+    .backup-actions {
+      width: 100%;
+    }
+
+    .backup-actions button {
+      flex: 1;
+      padding: 0.75rem;
+    }
+  }
+</style>

--- a/src/components/BackupsPanel.svelte
+++ b/src/components/BackupsPanel.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { backupsStore, formatBytes } from "../stores/backups";
+  import { invoke } from "@tauri-apps/api/core";
+  import BackupCard from "./BackupCard.svelte";
+  import { addMessage } from "$lib/stores";
+  import { Save, FolderOpen } from "lucide-svelte";
+  import { createBackupPopupStore } from "../stores/modStore";
+
+  onMount(() => {
+    backupsStore.load();
+  });
+
+  async function handleOpenFolder() {
+    try {
+      const dir = await backupsStore.getBackupsDirectory();
+      if (dir) {
+        await invoke("open_directory", { path: dir });
+      } else {
+        addMessage("Failed to get backups directory", "error");
+      }
+    } catch (e) {
+      addMessage(
+        `Failed to open backups folder: ${e instanceof Error ? e.message : String(e)}`,
+        "error"
+      );
+    }
+  }
+
+  function handleCreateClick() {
+    createBackupPopupStore.set({ visible: true });
+  }
+</script>
+
+<div class="backups-container">
+  <h2>Backups</h2>
+
+  <div class="actions-row">
+    <button class="action-button primary" onclick={handleCreateClick}>
+      <Save size={18} />
+      Create Backup
+    </button>
+    <button class="action-button secondary" onclick={handleOpenFolder}>
+      <FolderOpen size={18} />
+      Open Backups Folder
+    </button>
+  </div>
+
+  {#if $backupsStore.totalSize > 0}
+    <p class="size-info">Total backup size: <span class="highlight">{formatBytes($backupsStore.totalSize)}</span></p>
+  {/if}
+
+  {#if $backupsStore.loading && $backupsStore.backups.length === 0}
+    <div class="status-message">Loading backups...</div>
+  {:else if $backupsStore.error && $backupsStore.backups.length === 0}
+    <div class="status-message error">{$backupsStore.error}</div>
+  {:else if $backupsStore.backups.length === 0}
+    <div class="empty-state">
+      <p>No backups yet.</p>
+      <p class="hint">Create a backup to save your current mods configuration.</p>
+    </div>
+  {:else}
+    <div class="backups-list">
+      {#each $backupsStore.backups as backup (backup.id)}
+        <BackupCard {backup} />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .backups-container {
+    padding: 1.5rem;
+  }
+
+  h2 {
+    color: #fdcf51;
+    font-size: 2.8rem;
+    margin: 0 0 2rem 0;
+    font-family: "M6X11", sans-serif;
+    text-shadow:
+      -2px -2px 0 #000,
+      2px -2px 0 #000,
+      -2px 2px 0 #000,
+      2px 2px 0 #000;
+  }
+
+  .actions-row {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .action-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    border-radius: 6px;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+    box-shadow: 0 3px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .action-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 5px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .action-button:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .action-button.primary {
+    background: #56a786;
+    color: #f4eee0;
+    border: 2px solid #459373;
+  }
+
+  .action-button.primary:hover {
+    background: #67b897;
+  }
+
+  .action-button.secondary {
+    background: #ea9600;
+    color: #f4eee0;
+    border: 2px solid #cc8400;
+  }
+
+  .action-button.secondary:hover {
+    background: #fca800;
+  }
+
+  .size-info {
+    color: #f4eee0;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.15rem;
+    margin-bottom: 1rem;
+  }
+
+  .highlight {
+    color: #fdcf51;
+  }
+
+  .status-message {
+    color: #f4eee0;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.1rem;
+    padding: 2rem;
+    text-align: center;
+    opacity: 0.8;
+  }
+
+  .status-message.error {
+    color: #c14139;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: #f4eee0;
+    font-family: "M6X11", sans-serif;
+  }
+
+  .empty-state p {
+    margin: 0.5rem 0;
+    font-size: 1.3rem;
+  }
+
+  .empty-state .hint {
+    font-size: 1.15rem;
+    opacity: 0.7;
+  }
+
+  .backups-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  @media (max-width: 768px) {
+    .backups-container {
+      padding: 1rem;
+    }
+
+    h2 {
+      font-size: 1.8rem;
+    }
+
+    .actions-row {
+      flex-direction: column;
+    }
+
+    .action-button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+</style>

--- a/src/components/CreateBackupModal.svelte
+++ b/src/components/CreateBackupModal.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+  import { fade, scale } from "svelte/transition";
+  import { createBackupPopupStore } from "../stores/modStore";
+  import { backupsStore } from "../stores/backups";
+  import { addMessage } from "$lib/stores";
+
+  let backupName = $state("");
+  let isCreating = $state(false);
+
+  async function handleCreate() {
+    if (isCreating) return;
+    isCreating = true;
+
+    const backup = await backupsStore.createBackup(backupName.trim() || undefined);
+    if (backup) {
+      addMessage("Backup created successfully", "success");
+      handleClose();
+    } else if ($backupsStore.error) {
+      addMessage($backupsStore.error, "error");
+    }
+    isCreating = false;
+  }
+
+  function handleClose() {
+    backupName = "";
+    createBackupPopupStore.set({ visible: false });
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && !isCreating) {
+      handleCreate();
+    } else if (e.key === "Escape") {
+      handleClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if $createBackupPopupStore.visible}
+  <div class="modal-overlay" transition:fade={{ duration: 160 }}>
+    <div
+      class="modal-content"
+      transition:scale={{ duration: 160, start: 0.96 }}
+      role="dialog"
+      aria-modal="true"
+    >
+      <h3>Create Backup</h3>
+      <p class="subtitle">
+        Give your backup a name (optional). If left empty, it will be labeled as "Manual backup".
+      </p>
+
+      <div class="input-group">
+        <label for="backup-name">Backup Name</label>
+        <input
+          id="backup-name"
+          class="text-input"
+          type="text"
+          placeholder="My backup (optional)"
+          bind:value={backupName}
+        />
+      </div>
+
+      <div class="modal-actions">
+        <button class="create-button" onclick={handleCreate} disabled={isCreating}>
+          {isCreating ? "Creating..." : "Create"}
+        </button>
+        <button class="cancel-button" onclick={handleClose} disabled={isCreating}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    backdrop-filter: blur(2px);
+  }
+
+  :global([data-platform="linux"]) .modal-overlay {
+    backdrop-filter: none;
+    background: rgba(0, 0, 0, 0.92);
+  }
+
+  .modal-content {
+    width: 480px;
+    max-width: 90vw;
+    background: #393646;
+    color: #f4eee0;
+    border: 2px solid #f4eee0;
+    border-radius: 10px;
+    padding: 1.8rem;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  }
+
+  h3 {
+    margin: 0;
+    font-family: "M6X11", sans-serif;
+    font-size: 2.1rem;
+    color: #fdcf51;
+  }
+
+  .subtitle {
+    margin: 0.5rem 0 1.5rem;
+    color: rgba(244, 238, 224, 0.85);
+    font-size: 1.2rem;
+    line-height: 1.5;
+  }
+
+  .input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  label {
+    font-family: "M6X11", sans-serif;
+    font-size: 1.25rem;
+    color: #fdcf51;
+  }
+
+  .text-input {
+    background: #1f1f1f;
+    color: #f4eee0;
+    border: 2px solid #f4eee0;
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.2rem;
+  }
+
+  .text-input:focus {
+    outline: none;
+    border-color: #ea9600;
+    box-shadow: 0 0 0 2px rgba(234, 150, 0, 0.35);
+  }
+
+  .text-input::placeholder {
+    color: rgba(244, 238, 224, 0.4);
+  }
+
+  .text-input::selection {
+    background: #f4eee0;
+    color: #393646;
+  }
+
+  .modal-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  button {
+    border: none;
+    border-radius: 6px;
+    padding: 0.85rem 1.5rem;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, background-color 0.2s ease;
+    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .create-button {
+    background: #56a786;
+    color: #f4eee0;
+    border: 2px solid #459373;
+  }
+
+  .create-button:hover:not(:disabled) {
+    background: #67b897;
+  }
+
+  .cancel-button {
+    background: #ea9600;
+    color: #f4eee0;
+    border: 2px solid #cc8400;
+  }
+
+  .cancel-button:hover:not(:disabled) {
+    background: #fca800;
+  }
+
+  @media (max-width: 768px) {
+    .modal-content {
+      padding: 1.5rem;
+    }
+
+    h3 {
+      font-size: 1.6rem;
+    }
+
+    .subtitle {
+      font-size: 1rem;
+    }
+
+    .text-input {
+      font-size: 1rem;
+      padding: 0.65rem 0.8rem;
+    }
+
+    .modal-actions {
+      grid-template-columns: 1fr;
+    }
+
+    button {
+      padding: 0.8rem 1rem;
+      font-size: 1rem;
+    }
+  }
+</style>

--- a/src/components/DeleteBackupPopup.svelte
+++ b/src/components/DeleteBackupPopup.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import { fade, scale } from "svelte/transition";
+  import { deleteBackupPopupStore } from "../stores/modStore";
+  import { backupsStore } from "../stores/backups";
+  import { addMessage } from "$lib/stores";
+
+  let isProcessing = $state(false);
+
+  async function handleDelete() {
+    if (isProcessing) return;
+    isProcessing = true;
+
+    const backupId = $deleteBackupPopupStore.backupId;
+    const success = await backupsStore.deleteBackup(backupId);
+
+    if (success) {
+      addMessage("Backup deleted", "success");
+    } else if ($backupsStore.error) {
+      addMessage($backupsStore.error, "error");
+    }
+
+    isProcessing = false;
+    handleClose();
+  }
+
+  function handleClose() {
+    deleteBackupPopupStore.set({ visible: false, backupId: "", backupName: "" });
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape" && !isProcessing) {
+      handleClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if $deleteBackupPopupStore.visible}
+  <div class="dialog-overlay" transition:fade={{ duration: 160 }}>
+    <div
+      class="dialog-content"
+      transition:scale={{ duration: 160, start: 0.96 }}
+      role="dialog"
+      aria-modal="true"
+    >
+      <h3>Delete Backup?</h3>
+      <p class="dialog-text">
+        Are you sure you want to delete
+        <strong>"{$deleteBackupPopupStore.backupName}"</strong>?
+      </p>
+      <p class="dialog-warning">
+        This action cannot be undone.
+      </p>
+      <div class="dialog-actions">
+        <button class="delete-button" onclick={handleDelete} disabled={isProcessing}>
+          {isProcessing ? "Deleting..." : "Delete"}
+        </button>
+        <button class="cancel-button" onclick={handleClose} disabled={isProcessing}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .dialog-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    backdrop-filter: blur(2px);
+  }
+
+  :global([data-platform="linux"]) .dialog-overlay {
+    backdrop-filter: none;
+    background: rgba(0, 0, 0, 0.92);
+  }
+
+  .dialog-content {
+    width: 480px;
+    max-width: 90vw;
+    background: #393646;
+    color: #f4eee0;
+    border: 2px solid #f4eee0;
+    border-radius: 12px;
+    padding: 2rem;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  }
+
+  h3 {
+    color: #fdcf51;
+    font-size: 2.1rem;
+    margin: 0 0 1rem;
+    font-family: "M6X11", sans-serif;
+    text-align: center;
+  }
+
+  .dialog-text {
+    color: #f4eee0;
+    font-size: 1.25rem;
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+  }
+
+  .dialog-text strong {
+    color: #fdcf51;
+  }
+
+  .dialog-warning {
+    color: #c14139;
+    font-size: 1.15rem;
+    margin: 0 0 1.5rem;
+    line-height: 1.4;
+  }
+
+  .dialog-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  button {
+    border: none;
+    border-radius: 6px;
+    padding: 0.9rem 1.25rem;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, background-color 0.2s ease;
+    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .delete-button {
+    background: #c14139;
+    color: #f4eee0;
+    border: 2px solid #a13029;
+  }
+
+  .delete-button:hover:not(:disabled) {
+    background: #d2524a;
+  }
+
+  .cancel-button {
+    background: #ea9600;
+    color: #f4eee0;
+    border: 2px solid #cc8400;
+  }
+
+  .cancel-button:hover:not(:disabled) {
+    background: #fca800;
+  }
+
+  @media (max-width: 768px) {
+    .dialog-content {
+      padding: 1.5rem;
+    }
+
+    h3 {
+      font-size: 1.5rem;
+    }
+
+    .dialog-text {
+      font-size: 1rem;
+    }
+
+    .dialog-actions {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/RestoreBackupPopup.svelte
+++ b/src/components/RestoreBackupPopup.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import { fade, scale } from "svelte/transition";
+  import { restoreBackupPopupStore } from "../stores/modStore";
+  import { backupsStore } from "../stores/backups";
+  import { addMessage } from "$lib/stores";
+
+  let isProcessing = $state(false);
+
+  async function handleRestore() {
+    if (isProcessing) return;
+    isProcessing = true;
+
+    const backupId = $restoreBackupPopupStore.backupId;
+    const success = await backupsStore.restoreBackup(backupId);
+
+    if (success) {
+      addMessage("Backup restored successfully. Please restart the app.", "success");
+    } else if ($backupsStore.error) {
+      addMessage($backupsStore.error, "error");
+    }
+
+    isProcessing = false;
+    handleClose();
+  }
+
+  function handleClose() {
+    restoreBackupPopupStore.set({ visible: false, backupId: "", backupName: "" });
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape" && !isProcessing) {
+      handleClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if $restoreBackupPopupStore.visible}
+  <div class="dialog-overlay" transition:fade={{ duration: 160 }}>
+    <div
+      class="dialog-content"
+      transition:scale={{ duration: 160, start: 0.96 }}
+      role="dialog"
+      aria-modal="true"
+    >
+      <h3>Restore Backup?</h3>
+      <p class="dialog-text">
+        This will replace your current mods with the backed-up configuration from
+        <strong>"{$restoreBackupPopupStore.backupName}"</strong>.
+      </p>
+      <p class="dialog-hint">
+        Your current mods will be backed up automatically before restoring.
+      </p>
+      <div class="dialog-actions">
+        <button class="confirm-button" onclick={handleRestore} disabled={isProcessing}>
+          {isProcessing ? "Restoring..." : "Restore"}
+        </button>
+        <button class="cancel-button" onclick={handleClose} disabled={isProcessing}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .dialog-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    backdrop-filter: blur(2px);
+  }
+
+  :global([data-platform="linux"]) .dialog-overlay {
+    backdrop-filter: none;
+    background: rgba(0, 0, 0, 0.92);
+  }
+
+  .dialog-content {
+    width: 480px;
+    max-width: 90vw;
+    background: #393646;
+    color: #f4eee0;
+    border: 2px solid #f4eee0;
+    border-radius: 12px;
+    padding: 2rem;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  }
+
+  h3 {
+    color: #fdcf51;
+    font-size: 2.1rem;
+    margin: 0 0 1rem;
+    font-family: "M6X11", sans-serif;
+    text-align: center;
+  }
+
+  .dialog-text {
+    color: #f4eee0;
+    font-size: 1.25rem;
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+  }
+
+  .dialog-text strong {
+    color: #fdcf51;
+  }
+
+  .dialog-hint {
+    color: rgba(244, 238, 224, 0.75);
+    font-size: 1.15rem;
+    margin: 0 0 1.5rem;
+    line-height: 1.4;
+  }
+
+  .dialog-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  button {
+    border: none;
+    border-radius: 6px;
+    padding: 0.9rem 1.25rem;
+    font-family: "M6X11", sans-serif;
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, background-color 0.2s ease;
+    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .confirm-button {
+    background: #56a786;
+    color: #f4eee0;
+    border: 2px solid #459373;
+  }
+
+  .confirm-button:hover:not(:disabled) {
+    background: #67b897;
+  }
+
+  .cancel-button {
+    background: #ea9600;
+    color: #f4eee0;
+    border: 2px solid #cc8400;
+  }
+
+  .cancel-button:hover:not(:disabled) {
+    background: #fca800;
+  }
+
+  @media (max-width: 768px) {
+    .dialog-content {
+      padding: 1.5rem;
+    }
+
+    h3 {
+      font-size: 1.5rem;
+    }
+
+    .dialog-text {
+      font-size: 1rem;
+    }
+
+    .dialog-actions {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/UninstallDialog.svelte
+++ b/src/components/UninstallDialog.svelte
@@ -9,6 +9,7 @@
         updateAvailableStore,
     } from "../stores/modStore";
     import { forceRefreshCache } from "../stores/modCache";
+    import { createAutoBackup } from "../stores/backups";
 
 	// Component props for callbacks
 	export let onUninstalled:
@@ -63,6 +64,10 @@
         // Close immediately to avoid UI lock if backend hangs.
         show = false;
         uninstallDialogStore.update((s) => ({ ...s, show: false }));
+
+        // Create auto-backup before uninstall
+        await createAutoBackup("auto_uninstall", modName);
+
         // Optimistically update UI state; we'll reconcile with cache refresh after.
         if (actionToRun === "cascade") {
             const toClear = Array.isArray(dependents) ? dependents : [];

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -32,8 +32,13 @@ import { cardScale, darkMode } from "../../stores/ui";
 import { get } from "svelte/store";
 import ReportIssue from "../../components/ReportIssue.svelte";
 import CollectionPicker from "../../components/CollectionPicker.svelte";
+import BackupsPanel from "../../components/BackupsPanel.svelte";
+import CreateBackupModal from "../../components/CreateBackupModal.svelte";
+import RestoreBackupPopup from "../../components/RestoreBackupPopup.svelte";
+import DeleteBackupPopup from "../../components/DeleteBackupPopup.svelte";
 import { fade } from "svelte/transition";
 import { isLinuxPlatform } from "$lib/platform";
+import { backupsStore } from "../../stores/backups";
 
 	let currentSection = $state("mods");
 	let isLinux = $state(false);
@@ -328,6 +333,15 @@ import { isLinuxPlatform } from "$lib/platform";
 				Mods
 			</button>
 			<button
+				class:active={currentSection === "backups"}
+				onclick={() => {
+					currentSection = "backups";
+					backupsStore.load();
+				}}
+			>
+				Backups
+			</button>
+			<button
 				class:active={currentSection === "settings"}
 				onclick={() => (currentSection = "settings")}
 			>
@@ -351,6 +365,10 @@ import { isLinuxPlatform } from "$lib/platform";
 		<!-- All sections stay mounted for smooth transitions -->
 		<div class="section-wrapper" class:active={currentSection === "mods"}>
 			<Mods mod={null} {handleDependencyCheck} />
+		</div>
+
+		<div class="section-wrapper" class:active={currentSection === "backups"}>
+			<BackupsPanel />
 		</div>
 
 		<div class="section-wrapper" class:active={currentSection === "settings"}>
@@ -415,6 +433,9 @@ import { isLinuxPlatform } from "$lib/platform";
 	<CollectionPicker />
 	<CollectionImportPopup />
 	<ReportIssue />
+	<CreateBackupModal />
+	<RestoreBackupPopup />
+	<DeleteBackupPopup />
 
 <style>
 	.main-page {

--- a/src/stores/backups.ts
+++ b/src/stores/backups.ts
@@ -1,0 +1,197 @@
+import { writable, get } from "svelte/store";
+import { invoke } from "@tauri-apps/api/core";
+
+export type BackupTrigger =
+  | "auto_update"
+  | "auto_uninstall"
+  | "auto_bulk"
+  | "manual";
+
+export interface Backup {
+  id: string;
+  created_at: string;
+  trigger: BackupTrigger;
+  name: string | null;
+  mod_count: number;
+  size_bytes: number;
+  lovely_version: string | null;
+}
+
+export interface BackupsState {
+  backups: Backup[];
+  loading: boolean;
+  totalSize: number;
+  error: string | null;
+}
+
+function createBackupsStore() {
+  const { subscribe, set, update } = writable<BackupsState>({
+    backups: [],
+    loading: false,
+    totalSize: 0,
+    error: null,
+  });
+
+  return {
+    subscribe,
+
+    async load() {
+      update((s) => ({ ...s, loading: true, error: null }));
+      try {
+        const [backups, totalSize] = await Promise.all([
+          invoke<Backup[]>("list_backups"),
+          invoke<number>("get_backups_total_size"),
+        ]);
+        update((s) => ({
+          ...s,
+          backups,
+          totalSize,
+          loading: false,
+        }));
+      } catch (e) {
+        update((s) => ({
+          ...s,
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+        }));
+      }
+    },
+
+    async createBackup(name?: string): Promise<Backup | null> {
+      update((s) => ({ ...s, loading: true, error: null }));
+      try {
+        const backup = await invoke<Backup>("create_backup", {
+          trigger: "manual",
+          name: name || null,
+          context: null,
+        });
+        await this.load();
+        return backup;
+      } catch (e) {
+        update((s) => ({
+          ...s,
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+        }));
+        return null;
+      }
+    },
+
+    async restoreBackup(backupId: string): Promise<boolean> {
+      update((s) => ({ ...s, loading: true, error: null }));
+      try {
+        await invoke("restore_backup", { backupId });
+        update((s) => ({ ...s, loading: false }));
+        return true;
+      } catch (e) {
+        update((s) => ({
+          ...s,
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+        }));
+        return false;
+      }
+    },
+
+    async deleteBackup(backupId: string): Promise<boolean> {
+      update((s) => ({ ...s, loading: true, error: null }));
+      try {
+        await invoke("delete_backup", { backupId });
+        await this.load();
+        return true;
+      } catch (e) {
+        update((s) => ({
+          ...s,
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+        }));
+        return false;
+      }
+    },
+
+    async getBackupsDirectory(): Promise<string | null> {
+      try {
+        return await invoke<string>("get_backups_directory");
+      } catch {
+        return null;
+      }
+    },
+
+    async checkInterruptedRestore(): Promise<string | null> {
+      try {
+        return await invoke<string | null>("check_interrupted_restore");
+      } catch {
+        return null;
+      }
+    },
+
+    async clearInterruptedRestore(): Promise<void> {
+      try {
+        await invoke("clear_interrupted_restore");
+      } catch {
+        // Ignore errors
+      }
+    },
+
+    clearError() {
+      update((s) => ({ ...s, error: null }));
+    },
+  };
+}
+
+export const backupsStore = createBackupsStore();
+
+// Helper to create auto-backup before operations
+export async function createAutoBackup(
+  trigger: "auto_update" | "auto_uninstall" | "auto_bulk",
+  context?: string,
+): Promise<void> {
+  try {
+    await invoke("create_backup", {
+      trigger,
+      name: null,
+      context: context || null,
+    });
+  } catch (e) {
+    console.warn("Failed to create auto-backup:", e);
+  }
+}
+
+// Format bytes to human-readable size
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+// Format date to localized string
+export function formatBackupDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+// Get display name for backup
+export function getBackupDisplayName(backup: Backup): string {
+  if (backup.name) {
+    return backup.name;
+  }
+  switch (backup.trigger) {
+    case "auto_update":
+      return "Before updating mod";
+    case "auto_uninstall":
+      return "Before uninstalling mod";
+    case "auto_bulk":
+      return "Before bulk operation";
+    case "manual":
+      return "Manual backup";
+    default:
+      return "Backup";
+  }
+}

--- a/src/stores/backups.ts
+++ b/src/stores/backups.ts
@@ -1,4 +1,4 @@
-import { writable, get } from "svelte/store";
+import { writable } from "svelte/store";
 import { invoke } from "@tauri-apps/api/core";
 
 export type BackupTrigger =
@@ -25,7 +25,7 @@ export interface BackupsState {
 }
 
 function createBackupsStore() {
-  const { subscribe, set, update } = writable<BackupsState>({
+  const { subscribe, update } = writable<BackupsState>({
     backups: [],
     loading: false,
     totalSize: 0,

--- a/src/stores/modStore.ts
+++ b/src/stores/modStore.ts
@@ -392,3 +392,38 @@ export interface ReportIssueState {
 export const reportIssueStore = writable<ReportIssueState>({
   visible: false,
 });
+
+// CreateBackup popup state
+export interface CreateBackupPopupState {
+  visible: boolean;
+}
+
+export const createBackupPopupStore = writable<CreateBackupPopupState>({
+  visible: false,
+});
+
+// Backup restore confirmation popup state
+export interface RestoreBackupPopupState {
+  visible: boolean;
+  backupId: string;
+  backupName: string;
+}
+
+export const restoreBackupPopupStore = writable<RestoreBackupPopupState>({
+  visible: false,
+  backupId: "",
+  backupName: "",
+});
+
+// Backup delete confirmation popup state
+export interface DeleteBackupPopupState {
+  visible: boolean;
+  backupId: string;
+  backupName: string;
+}
+
+export const deleteBackupPopupStore = writable<DeleteBackupPopupState>({
+  visible: false,
+  backupId: "",
+  backupName: "",
+});

--- a/src/stores/popupManager.ts
+++ b/src/stores/popupManager.ts
@@ -7,6 +7,9 @@ import {
   securityPopupStore,
   updatePopupStore,
   reportIssueStore,
+  createBackupPopupStore,
+  restoreBackupPopupStore,
+  deleteBackupPopupStore,
   type LovelyPopupState,
   type UninstallDialogState,
   type WarningPopupState,
@@ -14,6 +17,9 @@ import {
   type SecurityPopupState,
   type UpdatePopupState,
   type ReportIssueState,
+  type CreateBackupPopupState,
+  type RestoreBackupPopupState,
+  type DeleteBackupPopupState,
 } from "./modStore";
 import {
   collectionImportStore,
@@ -41,7 +47,10 @@ export type PopupType =
   | "requires"
   | "security"
   | "update"
-  | "reportIssue";
+  | "reportIssue"
+  | "createBackup"
+  | "restoreBackup"
+  | "deleteBackup";
 
 /**
  * Represents the state of a popup that has been pushed to the stack.
@@ -114,6 +123,23 @@ function closePopupByType(type: PopupType): void {
     case "reportIssue":
       reportIssueStore.set({ visible: false });
       break;
+    case "createBackup":
+      createBackupPopupStore.set({ visible: false });
+      break;
+    case "restoreBackup":
+      restoreBackupPopupStore.set({
+        visible: false,
+        backupId: "",
+        backupName: "",
+      });
+      break;
+    case "deleteBackup":
+      deleteBackupPopupStore.set({
+        visible: false,
+        backupId: "",
+        backupName: "",
+      });
+      break;
   }
 }
 
@@ -158,6 +184,15 @@ function openPopupDirect(state: PopupState): void {
       break;
     case "reportIssue":
       reportIssueStore.set(state.data as ReportIssueState);
+      break;
+    case "createBackup":
+      createBackupPopupStore.set(state.data as CreateBackupPopupState);
+      break;
+    case "restoreBackup":
+      restoreBackupPopupStore.set(state.data as RestoreBackupPopupState);
+      break;
+    case "deleteBackup":
+      deleteBackupPopupStore.set(state.data as DeleteBackupPopupState);
       break;
   }
   // Reset transitioning flag after a microtask to allow store update to propagate
@@ -231,6 +266,9 @@ let prevStates: Record<PopupType, { open: boolean; data: unknown }> = {
   security: { open: false, data: null },
   update: { open: false, data: null },
   reportIssue: { open: false, data: null },
+  createBackup: { open: false, data: null },
+  restoreBackup: { open: false, data: null },
+  deleteBackup: { open: false, data: null },
 };
 
 /**
@@ -487,6 +525,83 @@ reportIssueStore.subscribe((state) => {
   prevStates.reportIssue = { open: isOpen, data: state };
 });
 
+createBackupPopupStore.subscribe((state) => {
+  const wasOpen = prevStates.createBackup.open;
+  const isOpen = state.visible;
+
+  if (isOpen && !wasOpen && !isTransitioning) {
+    const currentPopup = findCurrentlyOpenPopup("createBackup");
+    if (currentPopup) {
+      createBackupPopupStore.set({ visible: false });
+      handlePopupConflict(
+        currentPopup.type,
+        currentPopup.data,
+        "createBackup",
+        state,
+      );
+      return;
+    }
+  } else if (!isOpen && wasOpen && !isTransitioning) {
+    handlePopupClose();
+  }
+
+  prevStates.createBackup = { open: isOpen, data: state };
+});
+
+restoreBackupPopupStore.subscribe((state) => {
+  const wasOpen = prevStates.restoreBackup.open;
+  const isOpen = state.visible;
+
+  if (isOpen && !wasOpen && !isTransitioning) {
+    const currentPopup = findCurrentlyOpenPopup("restoreBackup");
+    if (currentPopup) {
+      restoreBackupPopupStore.set({
+        visible: false,
+        backupId: "",
+        backupName: "",
+      });
+      handlePopupConflict(
+        currentPopup.type,
+        currentPopup.data,
+        "restoreBackup",
+        state,
+      );
+      return;
+    }
+  } else if (!isOpen && wasOpen && !isTransitioning) {
+    handlePopupClose();
+  }
+
+  prevStates.restoreBackup = { open: isOpen, data: state };
+});
+
+deleteBackupPopupStore.subscribe((state) => {
+  const wasOpen = prevStates.deleteBackup.open;
+  const isOpen = state.visible;
+
+  if (isOpen && !wasOpen && !isTransitioning) {
+    const currentPopup = findCurrentlyOpenPopup("deleteBackup");
+    if (currentPopup) {
+      deleteBackupPopupStore.set({
+        visible: false,
+        backupId: "",
+        backupName: "",
+      });
+      handlePopupConflict(
+        currentPopup.type,
+        currentPopup.data,
+        "deleteBackup",
+        state,
+      );
+      return;
+    }
+  } else if (!isOpen && wasOpen && !isTransitioning) {
+    handlePopupClose();
+  }
+
+  prevStates.deleteBackup = { open: isOpen, data: state };
+});
+
 /**
  * Clear the popup stack (use when navigating away or resetting state).
  */
@@ -518,6 +633,9 @@ export const hasActivePopup = derived(
     securityPopupStore,
     updatePopupStore,
     reportIssueStore,
+    createBackupPopupStore,
+    restoreBackupPopupStore,
+    deleteBackupPopupStore,
   ],
   ([
     $lovely,
@@ -530,6 +648,9 @@ export const hasActivePopup = derived(
     $security,
     $update,
     $reportIssue,
+    $createBackup,
+    $restoreBackup,
+    $deleteBackup,
   ]) => {
     return (
       $lovely.visible ||
@@ -541,7 +662,10 @@ export const hasActivePopup = derived(
       $requires.visible ||
       $security.visible ||
       $update.visible ||
-      $reportIssue.visible
+      $reportIssue.visible ||
+      $createBackup.visible ||
+      $restoreBackup.visible ||
+      $deleteBackup.visible
     );
   },
 );


### PR DESCRIPTION
This pull request introduces a complete backup and restore feature to the application, including backend support, Tauri commands, and a full Svelte-based user interface for managing backups. Users can now create, view, restore, and delete mod configuration backups, with clear feedback and error handling throughout the process.

**Backend and API integration:**

- Added a new `backup` module to the backend, exposing Tauri commands for creating, listing, restoring, deleting, and managing backups, including support for manual and automatic triggers. [[1]](diffhunk://#diff-067109e4363b2f574cf36adf113e1e62154cacf37d56630ba4de63ee1d531822R23-R24) [[2]](diffhunk://#diff-b31ffbdaddc8fcb102701f0e2dec8f4313497ecda57eeefb1751d781ab69a6a1R1-R94) [[3]](diffhunk://#diff-0cf4fb109a3fae8ba5206964383c2404d530973510f3a999c3357c96e97868ccR1) [[4]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR461-R468)
- Enabled `serde` support for the `chrono` crate to facilitate serialization of backup metadata.

**Frontend UI for backups:**

- Added `BackupsPanel.svelte`, providing a user interface to view all backups, create new backups, and open the backups folder.
- Added `BackupCard.svelte` to display individual backup details and actions (restore, delete), with visual distinction for manual vs. automatic backups.
- Added `CreateBackupModal.svelte` for naming and creating backups with user feedback and keyboard shortcuts.
- Added `DeleteBackupPopup.svelte` for confirming and processing backup deletions, with error handling and feedback.

These changes provide a robust, user-friendly backup and restore experience for mod configurations, tightly integrated between the backend and frontend.