### PR TITLE
Update Flatpak runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,10 +166,10 @@ jobs:
       - name: Install Flatpak runtimes
         run: |
           flatpak install -y --user flathub \
-            org.gnome.Platform//47 \
-            org.gnome.Sdk//47 \
-            org.freedesktop.Sdk.Extension.node20//24.08 \
-            org.freedesktop.Sdk.Extension.rust-stable//24.08
+            org.gnome.Platform//50 \
+            org.gnome.Sdk//50 \
+            org.freedesktop.Sdk.Extension.node20//25.08 \
+            org.freedesktop.Sdk.Extension.rust-stable//25.08
       - name: Build Flatpak bundle
         run: |
           flatpak-builder --force-clean build-dir packaging/flatpak/io.balatro.ModManager.json

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ sudo apt install ./Balatro.Mod.Manager_*_amd64.deb
   git clone https://github.com/skyline69/balatro-mod-manager.git
   cd balatro-mod-manager
   ```
-- Install runtimes once (GNOME 47 + toolchain extensions):
+- Install runtimes once (GNOME 50 + toolchain extensions):
   ```bash
-  flatpak install org.gnome.Platform//47 org.gnome.Sdk//47 \
-    org.freedesktop.Sdk.Extension.node20//24.08 \
-    org.freedesktop.Sdk.Extension.rust-stable//24.08
+  flatpak install org.gnome.Platform//50 org.gnome.Sdk//50 \
+    org.freedesktop.Sdk.Extension.node20//25.08 \
+    org.freedesktop.Sdk.Extension.rust-stable//25.08
   ```
 - Build + bundle from this repo:
   ```bash

--- a/packaging/flatpak/io.balatro.ModManager.json
+++ b/packaging/flatpak/io.balatro.ModManager.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.balatro.ModManager",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "50",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.node20",

--- a/scripts/linux-install.sh
+++ b/scripts/linux-install.sh
@@ -157,7 +157,7 @@ if [[ -n "$RELEASE_URL" ]]; then
     if curl -fsSL "$RELEASE_URL" -o "$FLATPAK_BUNDLE"; then
         ensure_flathub_remote
         REQUIRED_RELEASE_RUNTIMES=(
-            "org.gnome.Platform//47"
+            "org.gnome.Platform//50"
         )
         MISSING_RELEASE_RUNTIMES=()
         for runtime in "${REQUIRED_RELEASE_RUNTIMES[@]}"; do
@@ -217,10 +217,10 @@ fi
 echo -e "${GREEN}flatpak-builder ✓${NC}"
 
 RUNTIMES=(
-    "org.gnome.Platform//47"
-    "org.gnome.Sdk//47"
-    "org.freedesktop.Sdk.Extension.node20//24.08"
-    "org.freedesktop.Sdk.Extension.rust-stable//24.08"
+    "org.gnome.Platform//50"
+    "org.gnome.Sdk//50"
+    "org.freedesktop.Sdk.Extension.node20//25.08"
+    "org.freedesktop.Sdk.Extension.rust-stable//25.08"
 )
 
 MISSING_RUNTIMES=()


### PR DESCRIPTION
The GNOME 47 runtime is deprecated. I've updated it to the latest GNOME 50 runtime, with the extensions being updated to the corresponding Freedesktop runtime 25.08. I downloaded the build at https://github.com/electricbrass/balatro-mod-manager/actions/runs/25822362096/artifacts/6980189405 and it seems to work without issue for me.